### PR TITLE
Add line ending configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.vue text eol=lf
+


### PR DESCRIPTION
By default git checks lines out with dos line endings on Windows.
*prettier* doesn't like these and will complain about these in the `.vue` files.

The `.gitattributes` file will check out all vue files with unix line endings.

Love to write one line prs ^^