### PR TITLE
Fix meta tags for embeds

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -23,7 +23,6 @@ export default {
           'Modrinth is a mod distribution platform. Modrinth is modern, easy to use, and built for modders. Modrinth currently supports Minecraft, including the forge and fabric mod loaders.',
       },
 
-      { hid: 'author', name: 'author', content: 'Modrinth' },
       { hid: 'publisher', name: 'publisher', content: 'Guavy LLC' },
       {
         hid: 'apple-mobile-web-app-title',

--- a/pages/mod/_id/index.vue
+++ b/pages/mod/_id/index.vue
@@ -56,34 +56,37 @@ export default {
       title: this.mod.title + ' - Modrinth',
       meta: [
         {
-          hid: 'description',
-          name: 'description',
-          content:
-            this.mod.description +
-            ' View other minecraft mods on Modrinth today! Modrinth is a new and modern Minecraft modding platform that is compatible with CurseForge too!',
+          hid: 'og:type',
+          name: 'og:type',
+          content: 'website',
         },
-
+        {
+          hid: 'og:title',
+          name: 'og:title',
+          content: this.mod.title,
+        },
         {
           hid: 'apple-mobile-web-app-title',
           name: 'apple-mobile-web-app-title',
           content: this.mod.title,
         },
         {
-          hid: 'og:site_name',
-          name: 'og:site_name',
-          content: this.mod.title,
+          hid: 'og:description',
+          name: 'og:description',
+          content: this.mod.description,
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content:
+            this.mod.description +
+            ' View other minecraft mods on Modrinth today! Modrinth is a new and modern Minecraft modding platform that is compatible with CurseForge too!',
         },
         {
           hid: 'og:url',
           name: 'og:url',
           content: `https://modrinth.com/mod/${this.mod.id}`,
         },
-        {
-          hid: 'og:description',
-          name: 'og:description',
-          content: this.mod.description,
-        },
-        { hid: 'og:type', name: 'og:type', content: 'article' },
         {
           hid: 'og:image',
           name: 'og:image',

--- a/pages/mod/_id/version/_version.vue
+++ b/pages/mod/_id/version/_version.vue
@@ -222,12 +222,12 @@ export default {
         {
           hid: 'apple-mobile-web-app-title',
           name: 'apple-mobile-web-app-title',
-          content: this.mod.title + ' - Modrinth',
+          content: this.mod.title,
         },
         {
-          hid: 'og:site_name',
-          name: 'og:site_name',
-          content: this.mod.title + ' - Modrinth',
+          hid: 'og:title',
+          name: 'og:title',
+          content: this.mod.title,
         },
         {
           hid: 'og:url',

--- a/pages/mod/_id/versions.vue
+++ b/pages/mod/_id/versions.vue
@@ -328,15 +328,14 @@ export default {
             this.mod.description +
             ' View other minecraft mods on Modrinth today! Modrinth is a new and modern Minecraft modding platform that is compatible with CurseForge too!',
         },
-
         {
           hid: 'apple-mobile-web-app-title',
           name: 'apple-mobile-web-app-title',
           content: this.mod.title,
         },
         {
-          hid: 'og:site_name',
-          name: 'og:site_name',
+          hid: 'og:title',
+          name: 'og:title',
           content: this.mod.title,
         },
         {
@@ -349,7 +348,7 @@ export default {
           name: 'og:description',
           content: this.mod.description,
         },
-        { hid: 'og:type', name: 'og:type', content: 'article' },
+        { hid: 'og:type', name: 'og:type', content: 'website' },
         {
           hid: 'og:image',
           name: 'og:image',


### PR DESCRIPTION
This switches around the meta tags to make embeds work.

There are still two issues:
1. It would be nice to be able to set the `author` meta tag properly; This requires processing the members list to find if it has a single author, or taking a team name instead.  I don't have the knowledge of this setup to make that change.
2. Currently the normal `description` tag has the mod's description with an appended statement about modrinth.  You should make that string constant somehow so that you can change it without modifying every page.