### PR TITLE
Fix latest version listing

### DIFF
--- a/pages/mods.vue
+++ b/pages/mods.vue
@@ -64,7 +64,7 @@
           :author="result.author"
           :name="result.title"
           :description="result.description"
-          :latest-version="result.versions[0]"
+          :latest-version="result.latest_version"
           :created-at="result.date_created"
           :updated-at="result.date_modified"
           :downloads="result.downloads.toString()"


### PR DESCRIPTION
This makes the frontend respect the `latest_version` returned in search results.  This does not change the latest-version displayed on a user's profile though, since that is already incorrect and doesn't retrieve to the versions listing.