### PR TITLE
Use "npm ci" instead of "npm install" in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```bash
 # install dependencies
-$ npm install
+$ npm ci
 
 # serve with hot reload at localhost:3000
 $ npm run dev


### PR DESCRIPTION
package-lock.json exists, use `npm ci` as it is a quicker install.

`npm ci` uses cached packages (if they exist, which they most likely do for common packages such as core.js etc.) in the NPM install directory.

Although `ci` removes node_modules, it stores the cleared modules in cache, allowing other projects to be installed quicker than before with the modules cached.

while `npm install` doesn't check if the package has been installed and cached.