### PR TITLE
Avoid 404 page while version is processed 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "prettier.endOfLine": "lf",
+  "editor.formatOnSave": true
+}

--- a/pages/mod/_id/index.vue
+++ b/pages/mod/_id/index.vue
@@ -33,11 +33,15 @@ export default {
     const versions = []
 
     for (const version of mod.versions) {
-      res = await axios.get(
-        `https://api.modrinth.com/api/v1/version/${version}`
-      )
-
-      versions.push(res.data)
+      try {
+        res = await axios.get(
+          `https://api.modrinth.com/api/v1/version/${version}`
+        )
+        versions.push(res.data)
+      } catch {
+        // eslint-disable-next-line no-console
+        console.log('Some versions may be missing...')
+      }
     }
 
     return {

--- a/pages/mod/_id/settings.vue
+++ b/pages/mod/_id/settings.vue
@@ -31,11 +31,15 @@ export default {
     const versions = []
 
     for (const version of mod.versions) {
-      res = await axios.get(
-        `https://api.modrinth.com/api/v1/version/${version}`
-      )
-
-      versions.push(res.data)
+      try {
+        res = await axios.get(
+          `https://api.modrinth.com/api/v1/version/${version}`
+        )
+        versions.push(res.data)
+      } catch {
+        // eslint-disable-next-line no-console
+        console.log('Some versions may be missing...')
+      }
     }
 
     return {

--- a/pages/mod/_id/version/_version.vue
+++ b/pages/mod/_id/version/_version.vue
@@ -131,11 +131,15 @@ export default {
 
     const versions = []
     for (const version of mod.versions) {
-      res = await axios.get(
-        `https://api.modrinth.com/api/v1/version/${version}`
-      )
-
-      versions.push(res.data)
+      try {
+        res = await axios.get(
+          `https://api.modrinth.com/api/v1/version/${version}`
+        )
+        versions.push(res.data)
+      } catch {
+        // eslint-disable-next-line no-console
+        console.log('Some versions may be missing...')
+      }
     }
 
     const version = versions.find((x) => x.id === data.params.version)

--- a/pages/mod/_id/versions.vue
+++ b/pages/mod/_id/versions.vue
@@ -236,11 +236,15 @@ export default {
 
     const versions = []
     for (const version of mod.versions) {
-      res = await axios.get(
-        `https://api.modrinth.com/api/v1/version/${version}`
-      )
-
-      versions.push(res.data)
+      try {
+        res = await axios.get(
+          `https://api.modrinth.com/api/v1/version/${version}`
+        )
+        versions.push(res.data)
+      } catch {
+        // eslint-disable-next-line no-console
+        console.log('Some versions may be missing...')
+      }
     }
 
     res = await axios.get(`https://api.modrinth.com/api/v1/tag/loader`)


### PR DESCRIPTION
Before:

- If a version was in processing, it would cause axios to throw a 404 error. 

After:

- When a 404 error is thrown, it is ignored.

You could maybe document which versions were processing and add them to the versions list as "processing"