### PR TITLE
Mod authors don't give rights to modrinth forever...

### DIFF
--- a/pages/legal/terms.vue
+++ b/pages/legal/terms.vue
@@ -145,7 +145,7 @@
           a worldwide, non-exclusive, royalty-free, and unrestricted license to
           use, reproduce, distribute copies, prepare derivative works of, or
           display Content in connection with Modrinth in any medium and for any
-          purpose (including commercial purposes), which is irrevocable.
+          purpose (including commercial purposes).
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Modrinth's terms has an issue similar to what overwolf used to have:

https://curseforge-ideas.overwolf.com/ideas/CF-I-222

Modrinth does not need a perpetual license to modify or prepare derivative works of Mods. Modrinth should be allowed to retain, but not display, distribute, or perform, or serve copies of mods that have been removed or deleted.