### PR TITLE
Fix Title for Dashboard pages

### DIFF
--- a/pages/dashboard/notifications.vue
+++ b/pages/dashboard/notifications.vue
@@ -128,6 +128,11 @@ export default {
       this.$nuxt.$loading.finish()
     },
   },
+  head() {
+    return {
+      title: 'Notifications - Modrinth',
+    }
+  },
 }
 </script>
 

--- a/pages/dashboard/projects.vue
+++ b/pages/dashboard/projects.vue
@@ -68,6 +68,11 @@ export default {
       mods: res.data,
     }
   },
+  head() {
+    return {
+      title: 'My mods - Modrinth',
+    }
+  },
 }
 </script>
 

--- a/pages/dashboard/settings.vue
+++ b/pages/dashboard/settings.vue
@@ -172,6 +172,11 @@ export default {
       this.$nuxt.$loading.finish()
     },
   },
+  head() {
+    return {
+      title: 'Settings - Modrinth',
+    }
+  },
 }
 </script>
 


### PR DESCRIPTION
This PR corrects the title of the dashboard pages for more consistency.

If ever you want to change the title for the mods page, there is no problem.