### PR TITLE
Fix summary tags being always escaped by XSS

### DIFF
--- a/plugins/compiled-markdown-directive.js
+++ b/plugins/compiled-markdown-directive.js
@@ -2,10 +2,17 @@ import Vue from 'vue'
 import xss from 'xss'
 import marked from 'marked'
 
+const options = {
+  whiteList: {
+    ...xss.whiteList,
+    summary: [],
+  },
+}
+
+const configuredXss = new xss.FilterXSS(options)
+
 function compileMarkdown(target, markdown) {
-  target.innerHTML = xss(marked(markdown), {
-    whiteList: Object.assign(xss.whiteList, { summary: [] }),
-  })
+  target.innerHTML = configuredXss.process(marked(markdown))
 }
 
 Vue.directive('compiled-markdown', {

--- a/plugins/compiled-markdown-directive.js
+++ b/plugins/compiled-markdown-directive.js
@@ -3,7 +3,9 @@ import xss from 'xss'
 import marked from 'marked'
 
 function compileMarkdown(target, markdown) {
-  target.innerHTML = xss(marked(markdown))
+  target.innerHTML = xss(marked(markdown), {
+    whiteList: Object.assign(xss.whiteList, { summary: [] }),
+  })
 }
 
 Vue.directive('compiled-markdown', {


### PR DESCRIPTION
This PR adds `summary` tags to XSS's whitelist. Previously, they were escaped, meaning that dropdowns could only have "Details" as the title. Here's an example of it working:
![image](https://user-images.githubusercontent.com/7559492/105091924-55b1e380-5a7f-11eb-9648-25ec718d6df8.png)
