### PR TITLE
Fix #85 (Notification icon sized incorrectly for short user names)

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -237,9 +237,11 @@ export default {
         position: relative;
         top: 50%;
         transform: translateY(-50%);
+        min-width: 12rem;
         .dropdown {
           position: relative;
           display: inline-block;
+          flex-grow: 1;
           &:hover .control {
             border-radius: var(--size-rounded-control);
             background: var(--color-button-bg);
@@ -264,9 +266,11 @@ export default {
             padding: 0.3rem 0.75rem;
             position: relative;
             z-index: 10;
+            width: 100%;
             .avatar {
               align-items: center;
               display: flex;
+              flex-grow: 1;
               .icon {
                 border-radius: 50%;
                 height: 2rem;


### PR DESCRIPTION
Fixes issue #85.

Since I couldn't really try this out in dev (I don't know how to login without GitHub lol) this should be tested before merging.

**How:** Mostly set the `min-width` of `.user-controls` and made the child elements use the full space.

**Addtional Notes:** It might make sense to center the user name on the button but I don't really know ¯\\\_(ツ)\_/¯

**Before:**
![image](https://user-images.githubusercontent.com/24505659/112824333-af8be680-908a-11eb-8280-b5148b6763ab.png)

**After:**
![image](https://user-images.githubusercontent.com/24505659/112824219-908d5480-908a-11eb-9c40-01db52ff8498.png)
