### PR TITLE
Add LiteLoader, Rift, 'Other' mod loaders (Fixes #148)

### DIFF
--- a/components/layout/ModPage.vue
+++ b/components/layout/ModPage.vue
@@ -372,7 +372,6 @@ import ExternalIcon from '~/assets/images/utils/external.svg?inline'
 
 import ForgeIcon from '~/assets/images/categories/forge.svg?inline'
 import FabricIcon from '~/assets/images/categories/fabric.svg?inline'
-
 import LiteLoaderIcon from '~/assets/images/categories/liteloader.svg?inline'
 import RiftIcon from '~/assets/images/categories/rift.svg?inline'
 import OtherLoaderIcon from '~/assets/images/categories/misc.svg?inline'

--- a/components/layout/ModPage.vue
+++ b/components/layout/ModPage.vue
@@ -304,6 +304,18 @@
                   v-if="version.loaders.includes('forge')"
                   class="loader"
                 />
+                <LiteLoaderIcon
+                  v-if="version.loaders.includes('liteloader')"
+                  class="loader"
+                />
+                <RiftIcon
+                  v-if="version.loaders.includes('rift')"
+                  class="loader"
+                />
+                <OtherLoaderIcon
+                  v-if="version.loaders.includes('otherloader')"
+                  class="loader"
+                />
                 <span
                   v-if="version.game_versions.length > 0"
                   class="game-version limit-text-width"
@@ -364,6 +376,10 @@ import ExternalIcon from '~/assets/images/utils/external.svg?inline'
 
 import ForgeIcon from '~/assets/images/categories/forge.svg?inline'
 import FabricIcon from '~/assets/images/categories/fabric.svg?inline'
+import LiteLoaderIcon from '~/assets/images/categories/liteloader.svg?inline'
+import RiftIcon from '~/assets/images/categories/rift.svg?inline'
+import OtherLoaderIcon from '~/assets/images/categories/misc.svg?inline'
+
 import Advertisement from '~/components/Advertisement'
 
 export default {
@@ -375,6 +391,9 @@ export default {
     ExternalIcon,
     ForgeIcon,
     FabricIcon,
+    LiteLoaderIcon,
+    RiftIcon,
+    OtherLoaderIcon,
     DownloadIcon,
     CalendarIcon,
     EditIcon,

--- a/components/ui/search/Categories.vue
+++ b/components/ui/search/Categories.vue
@@ -8,6 +8,18 @@
       <ForgeLoader aria-hidden="true" />
       Forge
     </p>
+    <p v-if="categories.includes('liteloader')">
+      <LiteLoader aria-hidden="true" />
+      LiteLoader
+    </p>
+    <p v-if="categories.includes('rift')">
+      <RiftLoader aria-hidden="true" />
+      Rift
+    </p>
+    <p v-if="categories.includes('otherloader')">
+      <OtherLoader aria-hidden="true" />
+      Other Modloaders
+    </p>
     <p v-if="categories.includes('technology')">
       <TechCategory aria-hidden="true" />
       Technology
@@ -75,6 +87,9 @@ import WorldGenCategory from '~/assets/images/categories/worldgen.svg?inline'
 
 import ForgeLoader from '~/assets/images/categories/forge.svg?inline'
 import FabricLoader from '~/assets/images/categories/fabric.svg?inline'
+import LiteLoader from '~/assets/images/categories/liteloader.svg?inline'
+import RiftLoader from '~/assets/images/categories/rift.svg?inline'
+import OtherLoader from '~/assets/images/categories/misc.svg?inline'
 
 export default {
   name: 'Categories',
@@ -93,6 +108,9 @@ export default {
     WorldGenCategory,
     ForgeLoader,
     FabricLoader,
+    LiteLoader,
+    RiftLoader,
+    OtherLoader,
   },
   props: {
     categories: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -20,7 +20,7 @@ export default {
         hid: 'description',
         name: 'description',
         content:
-          'Modrinth is a mod distribution platform. Modrinth is modern, easy to use, and built for modders. Modrinth currently supports Minecraft, including Forge and Fabric mod loaders.',
+          'Modrinth is a mod distribution platform. Modrinth is modern, easy to use, and built for modders. Modrinth currently supports Minecraft, including the Forge, Fabric, LiteLoader, and Rift mod loaders.',
       },
 
       { hid: 'publisher', name: 'publisher', content: 'Guavy LLC' },

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -37,7 +37,7 @@ export default {
         hid: 'description',
         name: 'description',
         content:
-          'View information about Modrinth, an open source modding platform here! Modrinth currently supports Minecraft, including the forge and fabric mod loaders.',
+          'View information about Modrinth, an open source modding platform here! Modrinth currently supports Minecraft, including the Forge, Fabric, LiteLoader, and Rift mod loaders.',
       },
       {
         hid: 'apple-mobile-web-app-title',

--- a/pages/legal/privacy.vue
+++ b/pages/legal/privacy.vue
@@ -196,7 +196,7 @@ export default {
         hid: 'description',
         name: 'description',
         content:
-          'The privacy policy of Modrinth, an open source modding platform. Modrinth currently supports Minecraft, including the forge and fabric mod loaders.',
+          'The privacy policy of Modrinth, an open source modding platform. Modrinth currently supports Minecraft, including the Forge, Fabric, LiteLoader, and Rift mod loaders.',
       },
       {
         hid: 'apple-mobile-web-app-title',

--- a/pages/legal/terms.vue
+++ b/pages/legal/terms.vue
@@ -169,7 +169,7 @@ export default {
         hid: 'description',
         name: 'description',
         content:
-          'The Terms of Service of Modrinth, an open source modding platform. Modrinth currently supports Minecraft, including the forge and fabric mod loaders.',
+          'The Terms of Service of Modrinth, an open source modding platform. Modrinth currently supports Minecraft, including the Forge, Fabric, LiteLoader, and Rift mod loaders.',
       },
       {
         hid: 'apple-mobile-web-app-title',

--- a/pages/mod/_id/versions.vue
+++ b/pages/mod/_id/versions.vue
@@ -64,6 +64,9 @@
           <td>
             <FabricIcon v-if="version.loaders.includes('fabric')" />
             <ForgeIcon v-if="version.loaders.includes('forge')" />
+            <LiteLoaderIcon v-if="version.loaders.includes('liteloader')" />
+            <RiftIcon v-if="version.loaders.includes('rift')" />
+            <OtherLoaderIcon v-if="version.loaders.includes('otherloader')" />
           </td>
           <td>{{ version.game_versions.join(', ') }}</td>
           <td>
@@ -97,12 +100,18 @@ import ModPage from '~/components/layout/ModPage'
 import DownloadIcon from '~/assets/images/utils/download.svg?inline'
 import ForgeIcon from '~/assets/images/categories/forge.svg?inline'
 import FabricIcon from '~/assets/images/categories/fabric.svg?inline'
+import LiteLoaderIcon from '~/assets/images/categories/liteloader.svg?inline'
+import RiftIcon from '~/assets/images/categories/rift.svg?inline'
+import OtherLoaderIcon from '~/assets/images/categories/misc.svg?inline'
 
 export default {
   components: {
     ModPage,
     ForgeIcon,
     FabricIcon,
+    LiteLoaderIcon,
+    RiftIcon,
+    OtherLoaderIcon,
     DownloadIcon,
   },
   auth: false,

--- a/pages/mod/create.vue
+++ b/pages/mod/create.vue
@@ -211,6 +211,9 @@
               <td>
                 <FabricIcon v-if="version.loaders.includes('fabric')" />
                 <ForgeIcon v-if="version.loaders.includes('forge')" />
+                <LiteLoaderIcon v-if="version.loaders.includes('liteloader')" />
+                <RiftIcon v-if="version.loaders.includes('rift')" />
+                <OtherLoaderIcon v-if="version.loaders.includes('otherloader')" />
               </td>
               <td>{{ version.game_versions.join(', ') }}</td>
               <td>
@@ -507,6 +510,9 @@ import MFooter from '~/components/layout/MFooter'
 
 import ForgeIcon from '~/assets/images/categories/forge.svg?inline'
 import FabricIcon from '~/assets/images/categories/fabric.svg?inline'
+import LiteLoaderIcon from '~/assets/images/categories/liteloader.svg?inline'
+import RiftIcon from '~/assets/images/categories/rift.svg?inline'
+import OtherLoaderIcon from '~/assets/images/categories/misc.svg?inline'
 
 export default {
   components: {
@@ -515,6 +521,9 @@ export default {
     Multiselect,
     ForgeIcon,
     FabricIcon,
+    LiteLoaderIcon,
+    RiftIcon,
+    OtherLoaderIcon,
   },
   async asyncData() {
     const [

--- a/pages/mods.vue
+++ b/pages/mods.vue
@@ -240,6 +240,30 @@
             >
               <ForgeLoader />
             </SearchFilter>
+            <SearchFilter
+              :active-filters="facets"
+              display-name="LiteLoader"
+              facet-name="categories:liteloader"
+              @toggle="toggleFacet"
+            >
+              <LiteLoader />
+            </SearchFilter>
+            <SearchFilter
+              :active-filters="facets"
+              display-name="Rift"
+              facet-name="categories:rift"
+              @toggle="toggleFacet"
+            >
+              <RiftLoader />
+            </SearchFilter>
+            <SearchFilter
+              :active-filters="facets"
+              display-name="Other Modloaders"
+              facet-name="categories:otherloader"
+              @toggle="toggleFacet"
+            >
+              <OtherLoader />
+            </SearchFilter>
             <h3>Minecraft Versions</h3>
             <SearchFilter
               :active-filters="showVersions"
@@ -309,6 +333,9 @@ import WorldGenCategory from '~/assets/images/categories/worldgen.svg?inline'
 
 import ForgeLoader from '~/assets/images/categories/forge.svg?inline'
 import FabricLoader from '~/assets/images/categories/fabric.svg?inline'
+import LiteLoaderIcon from '~/assets/images/categories/liteloader.svg?inline'
+import RiftIcon from '~/assets/images/categories/rift.svg?inline'
+import OtherLoaderIcon from '~/assets/images/categories/misc.svg?inline'
 
 import SearchIcon from '~/assets/images/utils/search.svg?inline'
 import ExitIcon from '~/assets/images/utils/exit.svg?inline'
@@ -338,6 +365,9 @@ export default {
     WorldGenCategory,
     ForgeLoader,
     FabricLoader,
+    LiteLoader,
+    RiftLoader,
+    OtherLoader,
     SearchIcon,
     ExitIcon,
   },


### PR DESCRIPTION
svgs for each of those loaders' icons still need to be supplied. I don't know how I would go about getting those.