### PR TITLE
Revert "Fix report button on own uer page"

### DIFF
--- a/pages/user/_id.vue
+++ b/pages/user/_id.vue
@@ -17,7 +17,7 @@
             </div>
           </div>
           <p v-if="user.bio" class="bio">{{ user.bio }}</p>
-          <div v-if="this.$auth.user.id != user.id" class="buttons">
+          <div class="buttons">
             <nuxt-link
               v-if="this.$auth.user"
               :to="`/report/create?id=${user.id}&t=user`"


### PR DESCRIPTION
Reverts modrinth/knossos#220

This check on the buttons DIV:
```js
v-if="this.$auth.user.id != user.id"
```

Occurs before this check on the button:
```js
v-if="this.$auth.user"
```

This causes an error because `this.$auth.user.id` is undefined when the user is not logged in. Both checks should be moved to either the button or DIV where:
 ```js
v-if="this.$auth.user && this.$auth.user.id != user.id"
```

![image](https://user-images.githubusercontent.com/44736536/119057255-fefedc80-b980-11eb-815a-02acd50e305a.png)
![image](https://user-images.githubusercontent.com/44736536/119057264-01613680-b981-11eb-8b52-d7638181e24d.png)
