### PR TITLE
Remove all uses of `process.env.domain`

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -37,7 +37,7 @@ export default async function (context) {
 
   if (!context.$auth.user) {
     return context.redirect(
-      `${context.$axios.defaults.baseURL}auth/init?url=${process.env.domain}${context.route.fullPath}`
+      `${context.$axios.defaults.baseURL}auth/init?url=${context.store.app.$config.utils.domain}${context.route.fullPath}`
     )
   }
 }

--- a/pages/dashboard/misc/revoke-token.vue
+++ b/pages/dashboard/misc/revoke-token.vue
@@ -54,7 +54,7 @@ export default {
     async logout() {
       this.$cookies.set('auth-token-reset', true)
       await this.$router.replace(
-        `auth/init?url=${process.env.domain}${this.$route.fullPath}`
+        `auth/init?url=${this.$store.app.$config.utils.domain}${this.$route.fullPath}`
       )
     },
   },

--- a/pages/dashboard/misc/revoke-token.vue
+++ b/pages/dashboard/misc/revoke-token.vue
@@ -51,11 +51,9 @@
 export default {
   components: {},
   methods: {
-    async logout() {
+    logout() {
       this.$cookies.set('auth-token-reset', true)
-      await this.$router.replace(
-        `auth/init?url=${this.$store.app.$config.utils.domain}${this.$route.fullPath}`
-      )
+      window.location.href = '/'
     },
   },
 }


### PR DESCRIPTION
Fixes a 404 error when trying to visit a page that requires you to be logged in.

Fixes the logout button on the revoke token page.