### PR TITLE
Fix first notification not performing action

### DIFF
--- a/pages/dashboard/notifications.vue
+++ b/pages/dashboard/notifications.vue
@@ -75,7 +75,8 @@ export default {
       this.$nuxt.$loading.start()
 
       try {
-        if (index) {
+        if (typeof index !== 'undefined') {
+          console.log('test2')
           const config = {
             method: notification.actions[index].action_route[0].toLowerCase(),
             url: `${notification.actions[index].action_route[1]}`,

--- a/pages/dashboard/notifications.vue
+++ b/pages/dashboard/notifications.vue
@@ -76,7 +76,6 @@ export default {
 
       try {
         if (typeof index !== 'undefined') {
-          console.log('test2')
           const config = {
             method: notification.actions[index].action_route[0].toLowerCase(),
             url: `${notification.actions[index].action_route[1]}`,


### PR DESCRIPTION
```js
if (index) {
    const config = {
        method: notification.actions[index].action_route[0].toLowerCase(),
        url: `${notification.actions[index].action_route[1]}`,
        headers: {
            Authorization: this.$auth.token,
        },
    }

    await this.$axios(config)
}
```
Due to the IF statement in the code above, (in the part that performs a notification action), if the notification is the first in the array (the most recent notification) the IF statement will fail, preventing the request from happening, while still deleting the notification. This is the source of many team member invite issues.

The PR changes the line to:
```js
if (typeof index !== 'undefined') {
```