### PR TITLE
Fix #237 by alphabetically sorting the licenses

### DIFF
--- a/pages/mod/_id/edit.vue
+++ b/pages/mod/_id/edit.vue
@@ -360,6 +360,7 @@ export default {
         }
       }
 
+      availableLicenses.sort((a, b) => a.name.localeCompare(b.name))
       return {
         mod,
         clientSideType: mod.client_side.charAt(0) + mod.client_side.slice(1),

--- a/pages/mod/create.vue
+++ b/pages/mod/create.vue
@@ -541,6 +541,7 @@ export default {
       ])
     ).map((it) => it.data)
 
+    availableLicenses.sort((a, b) => a.name.localeCompare(b.name))
     return {
       availableCategories,
       availableLoaders,


### PR DESCRIPTION
This is not a nice fix though because it leads to code duplication.