### PR TITLE
Allow users to login from search page when it is rendered serverside

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -199,7 +199,7 @@ export default {
   },
   computed: {
     authUrl() {
-      return `${this.$axios.defaults.baseURL}auth/init?url=${this.$store.app.$config.utils.domain}${this.$route.fullPath}`
+      return `${this.$axios.defaults.baseURL}auth/init?url=${this.$store.app.$config.utils.domain}${this.$route.path}`
     },
     userUrl() {
       return `/user/${this.$auth.user.id}`


### PR DESCRIPTION
Removes the query, `?q=` from the login URL.

Closes #256 