### PR TITLE
Change username to name

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -58,7 +58,9 @@
                 >
                   <button class="control" @click="toggleDropdown">
                     <div class="avatar">
-                      <span>{{ this.$auth.user.name }}</span>
+                      <span>{{
+                        this.$auth.user.name || this.$auth.user.username
+                      }}</span>
                       <AvatarIcon
                         :notif-count="this.$user.notifications.count"
                         :dropdown-bg="isDropdownOpen"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -58,7 +58,7 @@
                 >
                   <button class="control" @click="toggleDropdown">
                     <div class="avatar">
-                      <span>{{ this.$auth.user.username }}</span>
+                      <span>{{ this.$auth.user.name }}</span>
                       <AvatarIcon
                         :notif-count="this.$user.notifications.count"
                         :dropdown-bg="isDropdownOpen"

--- a/pages/mod/_id.vue
+++ b/pages/mod/_id.vue
@@ -425,7 +425,7 @@ export default {
       users.forEach((it) => {
         const index = members.findIndex((x) => x.user_id === it.id)
         members[index].avatar_url = it.avatar_url
-        members[index].name = it.username
+        members[index].name = it.name || it.username
       })
 
       const currentMember = data.$auth.user

--- a/pages/user/_id.vue
+++ b/pages/user/_id.vue
@@ -6,7 +6,7 @@
           <div class="user-info">
             <img :src="user.avatar_url" :alt="user.username" />
             <div class="text">
-              <h2>{{ user.username }}</h2>
+              <h2>{{ user.name }}</h2>
               <p v-if="user.role === 'admin'" class="badge red">Admin</p>
               <p v-if="user.role === 'moderator'" class="badge yellow">
                 Moderator

--- a/pages/user/_id.vue
+++ b/pages/user/_id.vue
@@ -6,7 +6,7 @@
           <div class="user-info">
             <img :src="user.avatar_url" :alt="user.username" />
             <div class="text">
-              <h2>{{ user.name }}</h2>
+              <h2>{{ user.user || user.username }}</h2>
               <p v-if="user.role === 'admin'" class="badge red">Admin</p>
               <p v-if="user.role === 'moderator'" class="badge yellow">
                 Moderator

--- a/pages/user/_id.vue
+++ b/pages/user/_id.vue
@@ -6,7 +6,7 @@
           <div class="user-info">
             <img :src="user.avatar_url" :alt="user.username" />
             <div class="text">
-              <h2>{{ user.user || user.username }}</h2>
+              <h2>{{ user.name || user.username }}</h2>
               <p v-if="user.role === 'admin'" class="badge red">Admin</p>
               <p v-if="user.role === 'moderator'" class="badge yellow">
                 Moderator


### PR DESCRIPTION
The user's name is displayed instead of their username in:
- The site header
- The profile page
- The mod members section

If the user's name is empty, their username will be used instead.