### PR TITLE
Fix a bug & add improvements to a couple moderation aspects

### DIFF
--- a/pages/dashboard/moderation.vue
+++ b/pages/dashboard/moderation.vue
@@ -31,6 +31,12 @@
             Approve
           </button>
           <button
+            class="button column unlist"
+            @click="changeModStatus(mod.id, 'unlisted', index)"
+          >
+            Unlist
+          </button>
+          <button
             class="button column reject"
             @click="changeModStatus(mod.id, 'rejected', index)"
           >
@@ -53,7 +59,9 @@
           <h5 class="title">
             Report for {{ report.item_type }}
             <nuxt-link
-              :to="report.item_type + '/' + report.item_id.replace(/\W/g, '')"
+              :to="
+                '/' + report.item_type + '/' + report.item_id.replace(/\W/g, '')
+              "
               >{{ report.item_id }}
             </nuxt-link>
           </h5>

--- a/pages/mod/_id/edit.vue
+++ b/pages/mod/_id/edit.vue
@@ -9,13 +9,13 @@
         Back
       </nuxt-link>
       <button
-        v-if="mod.status === 'rejected' || mod.status === 'draft'"
-        title="Submit for Review"
+        v-if="mod.status === 'rejected' || 'draft' || 'unlisted'"
+        title="Submit for approval"
         class="button column"
         :disabled="!this.$nuxt.$loading"
         @click="saveModReview"
       >
-        Submit for Review
+        Submit for approval
       </button>
       <button
         title="Save"

--- a/pages/mod/create.vue
+++ b/pages/mod/create.vue
@@ -12,12 +12,12 @@
           Save draft
         </button>
         <button
-          title="Create"
+          title="Submit for review"
           class="brand-button column"
           :disabled="!this.$nuxt.$loading"
           @click="createMod"
         >
-          Create
+          Submit for review
         </button>
       </header>
       <section class="essentials">


### PR DESCRIPTION
This PR fixes reports on the moderation dashboard going to `/dashboard/mod/_id` instead of to `/mod/_id`.
It also allows the ability for moderators to unlist mods in the queue from the frontend instead of having to do it via the backend.
![image](https://i.imgur.com/x8shSVn.png)
Unlisted mods should have the ability to resubmit for approval, so I've also changed "Submit for Review" to "Submit for approval", allowing unlisted mods to do that as well.
![image](https://i.imgur.com/OC8Vyfo.png)