### PR TITLE
Improve MIME type detection (fixes #279)

### DIFF
--- a/pages/mod/_id/newversion.vue
+++ b/pages/mod/_id/newversion.vue
@@ -93,7 +93,7 @@
             upload multiple.
           </span>
           <FileInput
-            accept="application/java-archive,application/x-java-archive"
+            accept="*.jar,application/*"
             multiple
             prompt="Choose files or drag them here"
             @change="updateVersionFiles"

--- a/pages/mod/_id/newversion.vue
+++ b/pages/mod/_id/newversion.vue
@@ -93,7 +93,7 @@
             upload multiple.
           </span>
           <FileInput
-            accept="*.jar,application/*"
+            accept=".jar,application/java-archive,application/x-java-archive"
             multiple
             prompt="Choose files or drag them here"
             @change="updateVersionFiles"

--- a/pages/mod/_id/newversion.vue
+++ b/pages/mod/_id/newversion.vue
@@ -93,7 +93,7 @@
             upload multiple.
           </span>
           <FileInput
-            accept="application/*"
+            accept="application/java-archive,application/x-java-archive"
             multiple
             prompt="Choose files or drag them here"
             @change="updateVersionFiles"

--- a/pages/mod/_id/version/_version/index.vue
+++ b/pages/mod/_id/version/_version/index.vue
@@ -132,10 +132,10 @@
         </div>
       </div>
       <FileInput
+        v-if="currentMember"
         accept=".jar,application/java-archive,application/x-java-archive"
         multiple
         prompt="Choose files or drag them here"
-        v-if="currentMember"
         class="file-input"
         @change="addFiles"
       />

--- a/pages/mod/_id/version/_version/index.vue
+++ b/pages/mod/_id/version/_version/index.vue
@@ -131,7 +131,14 @@
           </a>
         </div>
       </div>
-      <FileInput v-if="currentMember" class="file-input" @change="addFiles" />
+      <FileInput
+        accept=".jar,application/java-archive,application/x-java-archive"
+        multiple
+        prompt="Choose files or drag them here"
+        v-if="currentMember"
+        class="file-input"
+        @change="addFiles"
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
This allows the file selector to be correct across operating systems, and also brings parity between the file selector on newversion and version index.
Supersedes #280 