### PR TITLE
Fix a bug introduced in #278 ("submit for approval" always being present)

### DIFF
--- a/pages/mod/_id/edit.vue
+++ b/pages/mod/_id/edit.vue
@@ -9,7 +9,11 @@
         Back
       </nuxt-link>
       <button
-        v-if="mod.status === 'rejected' || 'draft' || 'unlisted'"
+        v-if="
+          mod.status === 'rejected' ||
+          mod.status === 'draft' ||
+          mod.status === 'unlisted'
+        "
         title="Submit for approval"
         class="button column"
         :disabled="!this.$nuxt.$loading"


### PR DESCRIPTION
This fixes a bug where the "Submit for approval" button was always present no matter the project status.

These things are finnicky.