### PR TITLE
Makes mod editing only send changed data

### DIFF
--- a/assets/styles/components.scss
+++ b/assets/styles/components.scss
@@ -364,7 +364,7 @@
           }
         }
       }
-      
+
       .tab:last-child {
         margin-bottom: 0;
       }
@@ -403,6 +403,12 @@
   }
   &:active {
     background-color: var(--color-button-bg-active);
+  }
+  &:disabled,
+  &[disabled] {
+    opacity: 0.6;
+    pointer-events: none;
+    cursor: not-allowed;
   }
 }
 

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -234,7 +234,7 @@ textarea {
   border: 2px solid transparent;
 
   &:focus,
-  &:hover {
+  &:hover:not([disabled]) {
     background: var(--color-button-bg-hover);
     color: var(--color-text);
     outline: none;
@@ -251,6 +251,13 @@ textarea {
 
   &::placeholder {
     color: var(--color-color-text);
+  }
+
+  &:disabled,
+  &[disabled] {
+    opacity: 0.6;
+    pointer-events: none;
+    cursor: not-allowed;
   }
 }
 

--- a/libs/getDifferences.js
+++ b/libs/getDifferences.js
@@ -1,0 +1,23 @@
+const equalArrays = (arr1, arr2) =>
+  arr1.length === arr2.length &&
+  arr1.every((element, index) => element === arr2[index])
+
+const isObject = (obj) => obj instanceof Object && !Array.isArray(obj)
+
+const isArray = (arr) => Array.isArray(arr)
+
+export default function getDifferences(obj1, obj2) {
+  const obj3 = {}
+  for (const key of Object.keys(obj1)) {
+    const val1 = obj1[key]
+    const val2 = obj2[key]
+    const areArrays = isArray(val1) && isArray(val2)
+    const areObjects = isObject(val1) && isObject(val2)
+    if (areObjects) {
+      const diff = getDifferences(val1, val2)
+      if (diff) obj3[key] = diff
+    } else if (areArrays && !equalArrays(val1, val2)) obj3[key] = val2
+    else if (val1 !== val2) obj3[key] = val2
+  }
+  return !!Object.keys(obj3).length && obj3
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "knossos",
       "version": "1.0.0",
       "dependencies": {
         "@nuxtjs/axios": "^5.12.5",

--- a/pages/mod/_id/settings.vue
+++ b/pages/mod/_id/settings.vue
@@ -23,7 +23,14 @@
         <span>
           This leads to a page where you can create a version for your mod.
         </span>
-        <nuxt-link class="button" to="newversion">Create version</nuxt-link>
+        <nuxt-link
+          class="button"
+          to="newversion"
+          :disabled="
+            (currentMember.permissions & UPLOAD_VERSION) !== UPLOAD_VERSION
+          "
+          >Create version</nuxt-link
+        >
       </label>
       <h3>Delete mod</h3>
       <label>
@@ -44,7 +51,10 @@
     </section>
     <div class="section-header columns team-invite">
       <h3 class="column-grow-1">Team members</h3>
-      <div class="column">
+      <div
+        v-if="(currentMember.permissions & MANAGE_INVITES) === MANAGE_INVITES"
+        class="column"
+      >
         <input
           id="username"
           v-model="currentUsername"
@@ -355,7 +365,12 @@ export default {
       this.$nuxt.$loading.finish()
     },
     showPopup() {
-      this.$refs.delete_popup.show()
+      if (
+        (this.currentMember.permissions & this.DELETE_MOD) ===
+        this.DELETE_MOD
+      ) {
+        this.$refs.delete_popup.show()
+      }
     },
     async deleteMod() {
       await this.$axios.delete(`mod/${this.mod.id}`, this.$auth.headers)


### PR DESCRIPTION
Instead of sending everything to the backend when editing a mod, this keeps track of the old mod data and before uploading checks the differences between them. Then it only uploads the changes.

Importantly, this fixes an issue where team members with the permission to change the mod body are denied when using knossos. (I would assume the issue also exists the other way around.)

Everything relating to donation links is commented out.

The preview mod icon is smaller.