### PR TITLE
Allow Youtube through iframes + using image syntax in markdown

### DIFF
--- a/plugins/compiled-markdown-directive.js
+++ b/plugins/compiled-markdown-directive.js
@@ -22,10 +22,6 @@ const options = {
           regex: /^https?:\/\/(www\.)?youtube\.com\/embed\//,
           remove: ['&autoplay=1'], // Prevents autoplay
         },
-        {
-          regex: /^https?:\/\/?discord\.com\/widget/,
-          remove: [],
-        },
       ]
 
       for (const source of allowedSources) {

--- a/plugins/compiled-markdown-directive.js
+++ b/plugins/compiled-markdown-directive.js
@@ -19,7 +19,8 @@ const options = {
     if (tag === 'iframe' && name === 'src') {
       const allowedSources = [
         {
-          regex: /^https?:\/\/(www\.)?youtube\.com\/embed\//,
+          regex:
+            /^https?:\/\/(www\.)?youtube\.com\/embed\/[a-zA-Z0-9_]{11}(\?&autoplay=[0-1]{1})?$/,
           remove: ['&autoplay=1'], // Prevents autoplay
         },
       ]

--- a/plugins/compiled-markdown-directive.js
+++ b/plugins/compiled-markdown-directive.js
@@ -40,8 +40,7 @@ const configuredXss = new xss.FilterXSS(options)
 const headerPrefix = 'user-defined-'
 
 const renderer = {
-  image(href) {
-    console.log(href)
+  image(href, text) {
     if (
       /^https?:\/\/(www\.)?youtube\.com\/watch\?v=[a-zA-Z0-9_]{11}$/.test(href)
     ) {
@@ -49,6 +48,8 @@ const renderer = {
         32,
         43
       )}" frameborder="0" allowfullscreen></iframe>`
+    } else {
+      return `<img src="${href}" alt="${text}">`
     }
   },
 }

--- a/plugins/compiled-markdown-directive.js
+++ b/plugins/compiled-markdown-directive.js
@@ -19,8 +19,7 @@ const options = {
     if (tag === 'iframe' && name === 'src') {
       const allowedSources = [
         {
-          regex:
-            /^https?:\/\/(www\.)?youtube\.com\/embed\/[a-zA-Z0-9_]{11}(\?&autoplay=[0-1]{1})?$/,
+          regex: /^https?:\/\/(www\.)?youtube\.com\/embed\/[a-zA-Z0-9_]{11}(\?&autoplay=[0-1]{1})?$/,
           remove: ['&autoplay=1'], // Prevents autoplay
         },
       ]

--- a/plugins/compiled-markdown-directive.js
+++ b/plugins/compiled-markdown-directive.js
@@ -12,6 +12,31 @@ const options = {
     h4: ['id'],
     h5: ['id'],
     h6: ['id'],
+    iframe: ['width', 'height', 'allowfullscreen', 'frameborder'],
+  },
+  onIgnoreTagAttr: (tag, name, value) => {
+    // Allow iframes from acceptable sources
+    if (tag === 'iframe' && name === 'src') {
+      const allowedSources = [
+        {
+          regex: /^https?:\/\/(www\.)?youtube\.com\/embed\//,
+          remove: ['&autoplay=1'], // Prevents autoplay
+        },
+        {
+          regex: /^https?:\/\/?discord\.com\/widget/,
+          remove: [],
+        },
+      ]
+
+      for (const source of allowedSources) {
+        if (source.regex.test(value)) {
+          for (const remove of source.remove) {
+            value = value.replace(remove, '')
+          }
+          return name + '="' + xss.escapeAttrValue(value) + '"'
+        }
+      }
+    }
   },
 }
 

--- a/plugins/compiled-markdown-directive.js
+++ b/plugins/compiled-markdown-directive.js
@@ -39,6 +39,22 @@ const options = {
 const configuredXss = new xss.FilterXSS(options)
 const headerPrefix = 'user-defined-'
 
+const renderer = {
+  image(href) {
+    console.log(href)
+    if (
+      /^https?:\/\/(www\.)?youtube\.com\/watch\?v=[a-zA-Z0-9_]{11}$/.test(href)
+    ) {
+      return `<iframe width="560" height="315" src="https://www.youtube.com/embed/${href.substring(
+        32,
+        43
+      )}" frameborder="0" allowfullscreen></iframe>`
+    }
+  },
+}
+
+marked.use({ renderer })
+
 function compileMarkdown(target, markdown) {
   target.innerHTML = configuredXss.process(marked(markdown, { headerPrefix }))
 }


### PR DESCRIPTION
Currently the XSS filter doesn't allow iframes. This PR allows iframes that come from specific sources, YouTube embeds. The `allowedSources` array contains all allowed sources. Source's are matched by checking a regex expression against the iframe's `src` url.

Youtube autoplay is disabled.

In addition, this PR extends the default markdown image syntax. Images with youtube links are autodetected and transformed into youtube embeds. The following is acceptable markdown syntax:
```
![](https://www.youtube.com/watch?v=lX6JcybgDF)
```