### PR TITLE
Allow specific styling in markdown (Text colors)

### DIFF
--- a/plugins/compiled-markdown-directive.js
+++ b/plugins/compiled-markdown-directive.js
@@ -13,7 +13,7 @@ const options = {
     h5: ['id'],
     h6: ['id'],
   },
-  onIgnoreTagAttr: (tag, value) => {
+  onIgnoreTagAttr: (name, tag, value) => {
     if (tag === 'style') {
       // Convert CSS styles to an array of arrays of each property and value
       const styles = value

--- a/plugins/compiled-markdown-directive.js
+++ b/plugins/compiled-markdown-directive.js
@@ -13,6 +13,35 @@ const options = {
     h5: ['id'],
     h6: ['id'],
   },
+  onIgnoreTagAttr: (tag, value) => {
+    if (tag === 'style') {
+      // Convert CSS styles to an array of arrays of each property and value
+      const styles = value
+        .split(';')
+        .map((style) => style.split(':').map((part) => part.trim()))
+
+      // Filter out disallowed CSS styles
+      const allowedStyles = [
+        'font-size',
+        'font-family',
+        'color',
+        'background-color',
+        'background',
+        'font-weight',
+        'font-style',
+        'text-decoration',
+        'text-align',
+      ]
+      styles.forEach((style, index) => {
+        if (!allowedStyles.includes(style[0])) {
+          styles.splice(index)
+        }
+      })
+
+      const filteredStyles = styles.map((style) => style.join(':')).join(';')
+      return tag + '="' + xss.escapeAttrValue(filteredStyles) + '"'
+    }
+  },
 }
 
 const configuredXss = new xss.FilterXSS(options)


### PR DESCRIPTION
This PR allows users to style HTML elements in Markdown using the `style` attribute on HTML elements.

### Example
![image](https://user-images.githubusercontent.com/44736536/127986787-883ee89c-b48a-4604-9d3b-2b3e41b55b98.png)

### Allowed CSS properties
```js
'font-size',
'font-family',
'color',
'background-color',
'background',
'font-weight',
'font-style',
'text-decoration',
'text-align',
```

### Reasoning
- Currently, Modrinth's main competitor has colored text support, and Modrinth does not.
- Requested feature on Discord.
- Not revolutionary, anything done with styling can already be accomplished with images.
- Why not a custom markdown element?
  - Coloring through pure Markdown syntax is not standardized, all results on Google suggest using HTML
  - Making a custom Markdown element with the current Markdown parser would be more work than switching parsers