### PR TITLE
Change doc url on main page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -150,7 +150,7 @@
           Modrinth's code is fully open source licensed under the GNU AGPL.
           We've created a high-performance Rust-based backend that is
           <span
-            ><a href="https://github.com/modrinth/labrinth/wiki"
+            ><a href="https://docs.modrinth.com/docs/intro" target="_blank"
               >fully documented</a
             ></span
           >


### PR DESCRIPTION
This PR is small (yes my all PR are smalls ^^) but he change the link of doc on main page for v2 (github wiki to https://docs.modrinth.com/docs/intro/).

Done this for v1 is maybe useless...