### PR TITLE
Add a roadmap page and prioritize mentioning that revenue is not yet implemented

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -139,6 +139,7 @@
         <a target="_blank" href="https://discord.gg/EUHuJHt">Discord</a>
         <a target="_blank" href="https://github.com/modrinth/knossos">GitHub</a>
         <a target="_blank" href="https://docs.modrinth.com">Docs</a>
+        <a target="_blank" href="/roadmap">Roadmap</a>
       </div>
       <div class="buttons">
         <nuxt-link to="/settings/privacy" class="iconified-button">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -34,15 +34,16 @@
         <h3>Built for developers</h3>
         <h1>The world's most modder-friendly platform</h1>
         <p>
+          <span>Note: The following is not yet implemented.</span> Check the
+          <a href="/roadmap">roadmap</a> to keep up to date on upcoming
+          features.
+        </p>
+        <p>
           Modrinth intends to give back to the community, not leech from it.
           That's why we plan to give creators <span>one hundred percent</span>
           of the ad revenue earned on their project pages back to them, while
           creating easy to use tools for every modder to publish their mods on
           the Modrinth platform.
-        </p>
-        <p>
-          <span>Note: This is currently not implemented.</span> There is no ETA
-          for when it will be.
         </p>
       </div>
       <div class="right columns workflow">
@@ -313,6 +314,10 @@ export default {
     span {
       color: var(--color-brand);
       font-weight: bold;
+    }
+
+    a {
+      color: var(--color-brand);
     }
   }
   &.left {

--- a/pages/roadmap.vue
+++ b/pages/roadmap.vue
@@ -35,17 +35,8 @@
         <li>And even more cool features that we haven't thought of yet!</li>
       </ul>
     </div>
-    <m-footer class="footer" centered padded />
   </div>
 </template>
-<script>
-import MFooter from '~/components/layout/MFooter'
-export default {
-  components: {
-    MFooter,
-  },
-}
-</script>
 <style lang="scss" scoped>
 .roadmap-content {
   margin-left: 15%;

--- a/pages/roadmap.vue
+++ b/pages/roadmap.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="page-container">
-    <div class="roadmap-content">
+  <div class="main">
+    <div class="card">
       <h1>Roadmap</h1>
       <p>
         This is a listing of completed, planned, and in progress features for
@@ -37,12 +37,19 @@
     </div>
   </div>
 </template>
+<script>
+export default {
+  auth: false,
+}
+</script>
 <style lang="scss" scoped>
-.roadmap-content {
-  margin-left: 15%;
+.main {
+  margin: var(--spacing-card-sm) auto;
+  max-width: 800px;
 }
 
 a {
-  color: var(--color-brand);
+  text-decoration: underline;
+  color: var(--color-link);
 }
 </style>

--- a/pages/roadmap.vue
+++ b/pages/roadmap.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="page-container">
+    <div class="roadmap-content">
+      <h1>Roadmap</h1>
+      <p>
+        This is a listing of completed, planned, and in progress features for
+        Modrinth. An up-to-date roadmap can also be found in our
+        <a href="https://discord.gg/EUHuJHt">Discord server</a>!
+      </p>
+      <h2>Completed</h2>
+      <ul>
+        <li>Create an alternative mod hosting platform</li>
+        <li>Implement fast and accurate search</li>
+        <li>Be transparent and public</li>
+        <li>Create an open and robust API</li>
+        <li>Comply with the GDPR and protect your privacy</li>
+        <li>Provide quality-of-life features like notifications, and more</li>
+        <li>Allow creators to team up and manage permissions</li>
+      </ul>
+      <h2>In Progress</h2>
+      <ul>
+        <li>Implement modpacks and support for project types</li>
+        <li>A gallery system for projects to show off screenshots</li>
+        <li>An overhauled frontend</li>
+        <li>A way for projects to specify dependencies</li>
+        <li>Squash bugs and fix problems</li>
+        <li>Fully document our API</li>
+      </ul>
+      <h2>Planned</h2>
+      <ul>
+        <li>Pay creators a share of ads money</li>
+        <li>Automate platform migration process</li>
+        <li>Roll out our own authentication service</li>
+        <li>Provide analytics and stats to creators</li>
+        <li>And even more cool features that we haven't thought of yet!</li>
+      </ul>
+    </div>
+    <m-footer class="footer" centered padded />
+  </div>
+</template>
+<script>
+import MFooter from '~/components/layout/MFooter'
+export default {
+  components: {
+    MFooter,
+  },
+}
+</script>
+<style lang="scss" scoped>
+.roadmap-content {
+  margin-left: 15%;
+}
+
+a {
+  color: var(--color-brand);
+}
+</style>


### PR DESCRIPTION
This resolves #322.

Adding a roadmap to the site not only makes it more available, but the included link also draws more members into the Discord server.

Also, I'm brand new to Vue.js, so any criticism is, of course, welcome.