### PR TITLE
Add OpenSearch for searching mods in browser bar

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -60,6 +60,12 @@ export default {
         href:
           'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap',
       },
+      {
+        rel: 'search',
+        type: 'application/opensearchdescription+xml',
+        href: '/opensearch.xml',
+        title: 'Modrinth mods',
+      },
     ],
     script: [],
   },

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Modrinth mods</ShortName>
+  <Description>Search for mods on Modrinth, the open source modding platform.</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">https://modrinth.com/favicon.ico</Image>
+  <Url type="text/html" method="get" template="https://modrinth.com/mods?q={searchTerms}"/>
+  <Developer>Guavy LLC</Developer>
+  <Attribution>Guavy LLC</Attribution>
+  <moz:SearchForm>https://modrinth.com/mods</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
For more about OpenSearch, see [the official spec](https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md) or the [Mozilla dev wiki page](https://developer.mozilla.org/en-US/docs/Web/OpenSearch).

Video demonstration: https://streamable.com/r7ct7c