### PR TITLE
Fix changelog textarea being unusably small

### DIFF
--- a/pages/_type/_id/version.vue
+++ b/pages/_type/_id/version.vue
@@ -137,7 +137,12 @@
           :items="['source', 'preview']"
         />
         <div v-if="changelogViewMode === 'source'" class="textarea-wrapper">
-          <textarea id="body" v-model="version.changelog" />
+          <textarea
+            id="body"
+            v-model="version.changelog"
+            class="changelog-textarea"
+            spellcheck="true"
+          />
         </div>
         <div
           v-if="changelogViewMode === 'preview'"
@@ -1047,5 +1052,17 @@ section {
 
 .styled-tabs {
   margin-bottom: var(--spacing-card-sm);
+}
+
+.textarea-wrapper {
+  display: inline-block;
+  width: 100%;
+}
+
+.changelog-textarea {
+  resize: vertical;
+  width: calc(100% - var(--spacing-card-lg) - var(--spacing-card-md));
+  min-height: 10rem;
+  display: block;
 }
 </style>


### PR DESCRIPTION
It's now larger by default and is resizable:
![image](https://user-images.githubusercontent.com/6166773/156879840-8c0f98c8-d64d-4d38-895d-3ece7389ee22.png)
