### PR TITLE
Loader workarounds due to missing backend changes

### DIFF
--- a/components/ui/Checkbox.vue
+++ b/components/ui/Checkbox.vue
@@ -9,11 +9,12 @@
       class="checkbox"
       role="checkbox"
       :disabled="disabled"
-      :class="{ checked: value }"
+      :class="{ checked: value, collapsing: collapsingToggleStyle }"
       :aria-label="description"
       :aria-checked="value"
     >
-      <CheckIcon v-if="value" aria-hidden="true" />
+      <CheckIcon v-if="value && !collapsingToggleStyle" aria-hidden="true" />
+      <DropdownIcon v-else-if="collapsingToggleStyle" aria-hidden="true" />
     </button>
     <!-- aria-hidden is set so screenreaders only use the <button>'s aria-label -->
     <p v-if="label" aria-hidden="true">{{ label }}</p>
@@ -23,11 +24,13 @@
 
 <script>
 import CheckIcon from '~/assets/images/utils/check.svg?inline'
+import DropdownIcon from '~/assets/images/utils/dropdown.svg?inline'
 
 export default {
   name: 'Checkbox',
   components: {
     CheckIcon,
+    DropdownIcon,
   },
   props: {
     label: {
@@ -46,6 +49,10 @@ export default {
     clickEvent: {
       type: Function,
       default: () => {},
+    },
+    collapsingToggleStyle: {
+      type: Boolean,
+      default: false,
     },
   },
   methods: {
@@ -89,6 +96,10 @@ export default {
   &:hover {
     color: var(--color-heading);
 
+    .checkbox.collapsing svg {
+      color: var(--color-heading);
+    }
+
     button {
       background-color: var(--color-button-bg-hover);
 
@@ -97,8 +108,13 @@ export default {
       }
     }
   }
+
   &:active {
     color: var(--color-text-dark);
+
+    .checkbox.collapsing svg {
+      color: var(--color-text-dark);
+    }
 
     button {
       background-color: var(--color-button-bg-active);
@@ -132,6 +148,23 @@ export default {
     height: 0.8rem;
     width: 0.8rem;
     flex-shrink: 0;
+  }
+
+  &.collapsing {
+    background-color: transparent !important;
+
+    svg {
+      color: inherit;
+      height: 1rem;
+      width: 1rem;
+      transition: transform 0.25s ease-in-out;
+    }
+
+    &.checked {
+      svg {
+        transform: rotate(180deg);
+      }
+    }
   }
 }
 </style>

--- a/components/ui/search/Categories.vue
+++ b/components/ui/search/Categories.vue
@@ -3,7 +3,10 @@
     <span
       v-for="category in categoriesFiltered"
       :key="category.name"
-      v-html="category.icon + category.name"
+      v-html="
+        category.icon +
+        (category.name === 'modloader' ? 'ModLoader' : category.name)
+      "
     />
   </div>
 </template>

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -67,15 +67,33 @@
               Loaders
             </h3>
             <SearchFilter
-              v-for="loader in $tag.loaders.filter((x) =>
-                x.supported_project_types.includes(projectType)
-              )"
+              v-for="loader in $tag.loaders.filter((x) => {
+                if (
+                  !showAllLoaders &&
+                  x.name !== 'forge' &&
+                  x.name !== 'fabric' &&
+                  x.name !== 'quilt'
+                ) {
+                  return false
+                }
+                return x.supported_project_types.includes(projectType)
+              })"
               :key="loader.name"
               :active-filters="orFacets"
-              :display-name="loader.name"
+              :display-name="
+                loader.name === 'modloader' ? 'ModLoader' : loader.name
+              "
               :facet-name="`categories:${loader.name}`"
               :icon="loader.icon"
               @toggle="toggleOrFacet"
+            />
+            <Checkbox
+              v-model="showAllLoaders"
+              :label="showAllLoaders ? 'Less' : 'More'"
+              description="Show all loaders"
+              style="margin-bottom: 0.5rem"
+              :border="false"
+              :collapsing-toggle-style="true"
             />
           </section>
           <section aria-label="Environment filters">
@@ -326,6 +344,7 @@ export default {
       maxResults: 20,
 
       sidebarMenuOpen: false,
+      showAllLoaders: false,
 
       skipLink: '#search-results',
     }


### PR DESCRIPTION
As a temporary workaround until we get the ability to "feature" loaders and give them display names, these changes add the following things:

A "More" button to show more loaders that are hidden by default
![image](https://user-images.githubusercontent.com/6166773/169673017-4da46216-5c81-443e-9ad9-7251cbc16aba.png)

ModLoader is now capitalized properly
![image](https://user-images.githubusercontent.com/6166773/169673033-dd18e40b-744f-41a8-8117-3e91f789c7e0.png)
