### PR TITLE
Mobile category overlap fix

### DIFF
--- a/components/ui/ProjectCard.vue
+++ b/components/ui/ProjectCard.vue
@@ -362,6 +362,7 @@ export default {
   @media screen and (max-width: 560px) {
     .card-content {
       flex-direction: column;
+      margin-left: 0.8rem;
 
       .info {
         .dates {
@@ -390,7 +391,7 @@ export default {
 
     .left-categories {
       display: flex;
-      margin: 0 0 0.75rem 0.75rem;
+      margin: 0 0 0.75rem 0;
       width: 7rem;
     }
 

--- a/components/ui/ProjectCard.vue
+++ b/components/ui/ProjectCard.vue
@@ -362,7 +362,7 @@ export default {
   @media screen and (max-width: 560px) {
     .card-content {
       flex-direction: column;
-      margin-left: 0.8rem;
+      margin-left: 0.75rem;
 
       .info {
         .dates {


### PR DESCRIPTION
Fixes some overlap on cards

Before:
![image](https://user-images.githubusercontent.com/36215135/169711371-2c956bef-8e96-4aa6-882f-601aaab34ef5.png)

After:
![image](https://user-images.githubusercontent.com/36215135/169711436-d5d16ab4-b50c-4814-9f7a-3e02b7648795.png)
