### PR TITLE
iOS video fix

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -47,6 +47,7 @@
             loop
             muted
             src="~/assets/images/search.mp4"
+            playsinline
           />
           <video
             v-else
@@ -54,6 +55,7 @@
             loop
             muted
             src="~/assets/images/search-dark.mp4"
+            playsinline
           />
         </div>
         <div class="text-container">


### PR DESCRIPTION
On iOS when navigating to the homepage from a different page, the search videos immediately go full screen (even if they're hidden) which is annoying.