### PR TITLE
Add date tooltips

### DIFF
--- a/components/ui/ProjectCard.vue
+++ b/components/ui/ProjectCard.vue
@@ -66,11 +66,21 @@
             class="right-categories"
           />
           <div class="dates">
-            <div class="date">
+            <div
+              v-tooltip="
+                $dayjs(createdAt).format('MMMM D, YYYY [at] h:mm:ss A')
+              "
+              class="date"
+            >
               <CalendarIcon aria-hidden="true" />
               Created {{ $dayjs(createdAt).fromNow() }}
             </div>
-            <div class="date">
+            <div
+              v-tooltip="
+                $dayjs(updatedAt).format('MMMM D, YYYY [at] h:mm:ss A')
+              "
+              class="date"
+            >
               <EditIcon aria-hidden="true" />
               Updated {{ $dayjs(updatedAt).fromNow() }}
             </div>

--- a/pages/_type/_id.vue
+++ b/pages/_type/_id.vue
@@ -88,12 +88,18 @@
           >
         </div>
         <div class="dates">
-          <div class="date">
+          <div
+            v-tooltip="$dayjs(createdAt).format('MMMM D, YYYY [at] h:mm:ss A')"
+            class="date"
+          >
             <CalendarIcon aria-hidden="true" />
             <span class="label">Created</span>
             <span class="value">{{ $dayjs(project.published).fromNow() }}</span>
           </div>
-          <div class="date">
+          <div
+            v-tooltip="$dayjs(updatedAt).format('MMMM D, YYYY [at] h:mm:ss A')"
+            class="date"
+          >
             <UpdateIcon aria-hidden="true" />
             <span class="label">Updated</span>
             <span class="value">{{ $dayjs(project.updated).fromNow() }}</span>


### PR DESCRIPTION
This adds a tooltip that appears whenever you hover over the Created/Updated text in search results and mod pages. Example:
![date](https://user-images.githubusercontent.com/21112968/170807209-2fb3c407-bef1-4dcd-b8c1-c09884c633fb.gif)