### PR TITLE
Add "See all" link next to featured versions

### DIFF
--- a/pages/_type/_id.vue
+++ b/pages/_type/_id.vue
@@ -421,6 +421,16 @@
               />
             </div>
           </div>
+          <div class="links">
+            <nuxt-link
+              v-if="project.versions.length > 0 || currentMember"
+              :to="`/${project.project_type}/${
+                project.slug ? project.slug : project.id
+              }/versions`"
+            >
+              <span>All versions</span>
+            </nuxt-link>
+          </div>
           <hr class="card-divider" />
         </template>
         <h3 class="card-header">Project members</h3>

--- a/pages/_type/_id.vue
+++ b/pages/_type/_id.vue
@@ -362,6 +362,15 @@
         </template>
         <template v-if="featuredVersions.length > 0">
           <h3 class="card-header">Featured versions</h3>
+          <span class="links">
+            <nuxt-link
+              v-if="project.versions.length > 0 || currentMember"
+              :to="`/${project.project_type}/${
+                project.slug ? project.slug : project.id
+              }/versions`"
+              ><span>(See all)</span></nuxt-link
+            ></span
+          >
           <div
             v-for="version in featuredVersions"
             :key="version.id"
@@ -420,16 +429,6 @@
                 color="red"
               />
             </div>
-          </div>
-          <div class="links">
-            <nuxt-link
-              v-if="project.versions.length > 0 || currentMember"
-              :to="`/${project.project_type}/${
-                project.slug ? project.slug : project.id
-              }/versions`"
-            >
-              <span>All versions</span>
-            </nuxt-link>
           </div>
           <hr class="card-divider" />
         </template>
@@ -966,6 +965,8 @@ export default {
   font-weight: bold;
   color: var(--color-heading);
   margin-bottom: 0.3rem;
+  width: fit-content;
+  display: inline;
 }
 
 .featured-version {


### PR DESCRIPTION
A couple of friends and I who started using Modrinth recently didn't realize the "versions" tab existed right away. This PR aims to provide a way for users to easily find and access the "versions" tab from the "featured versions" section.