### PR TITLE
Broken mobile search fix

### DIFF
--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -133,7 +133,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .search-controls {
   display: flex;
   flex-direction: row;

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -670,6 +670,7 @@ export default {
   display: flex;
   flex-direction: row;
   gap: var(--spacing-card-md);
+  flex-wrap: wrap;
 
   .sort-controls {
     width: 100%;


### PR DESCRIPTION
Also adds `scoped` to `VersionFilterControl`'s `<style>` tag, it was causing differences between dev and prod.