### PR TITLE
Hoverable "joined" fields on user pages

### DIFF
--- a/components/ui/ProjectCard.vue
+++ b/components/ui/ProjectCard.vue
@@ -310,6 +310,7 @@ export default {
           display: flex;
           align-items: center;
           margin-right: 2rem;
+          cursor: default;
 
           svg {
             width: 1.25rem;

--- a/pages/_type/_id.vue
+++ b/pages/_type/_id.vue
@@ -918,6 +918,7 @@ export default {
       display: flex;
       align-items: center;
       margin-bottom: 0.25rem;
+      cursor: default;
 
       .label {
         margin-right: 0.25rem;

--- a/pages/user/_id.vue
+++ b/pages/user/_id.vue
@@ -31,7 +31,12 @@
         <div class="sidebar__item stats-block">
           <div class="stats-block__item secondary-stat">
             <SunriseIcon class="secondary-stat__icon" aria-hidden="true" />
-            <span class="secondary-stat__text">
+            <span
+              v-tooltip="
+                $dayjs(user.created).format('MMMM D, YYYY [at] h:mm:ss A')
+              "
+              class="secondary-stat__text date"
+            >
               Joined {{ $dayjs(user.created).fromNow() }}
             </span>
           </div>
@@ -327,5 +332,9 @@ export default {
 .primary-stat__counter {
   font-size: var(--font-size-lg);
   font-weight: bold;
+}
+
+.date {
+  cursor: default;
 }
 </style>


### PR DESCRIPTION
Implemented #540 and now the cursor does not change to "text" on hoverable "date" fields. Instead, it remains the "default" cursor.
I think it looks cleaner, but I can remove it if the Modrinth Team doesn't like it.