### PR TITLE
Create config.yml for issue selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-enable_blank_issues: true
+blank_issues_enabled: true
 contact_links:
   - name: Discord
     about: Ask questions on our Discord Server.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+enable_blank_issues: true
+contact_links:
+  - name: Discord
+    about: Ask questions on our Discord Server.
+    url: https://discord.gg/EUHuJHt
+  - name: Documentation
+    about: Useful documentation about Modrinth, its API and how you can contribute.
+    url: https://docs.modrinth.com

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     about: Ask questions on our Discord Server.
     url: https://discord.gg/EUHuJHt
   - name: Documentation
-    about: Useful documentation about Modrinth, its API and how you can contribute.
+    about: Useful documentation about Modrinth, its API, and how you can contribute.
     url: https://docs.modrinth.com


### PR DESCRIPTION
Adds a config.yml to `.github/ISSUE_TEMPLATE/` which allows to show links to useful pages.

I decided to include the GitHub Invite and Modrinth documentation page. If any other pages should be added, let me know.

I also left `blank_issues_enabled` on true. If that should be changed, let me know too.