### PR TITLE
Allow setting pixelated image-rendering

### DIFF
--- a/plugins/xss.js
+++ b/plugins/xss.js
@@ -1,5 +1,8 @@
 import xss from 'xss'
 
+/**
+ * @type {import('xss').IFilterXSSOptions}
+ */
 const options = {
   whiteList: {
     ...xss.whiteList,
@@ -12,6 +15,12 @@ const options = {
     h6: ['id'],
     input: ['checked', 'disabled', 'type'],
     iframe: ['width', 'height', 'allowfullscreen', 'frameborder'],
+    img: [...xss.whiteList.img, 'style'],
+  },
+  css: {
+    whiteList: {
+      'image-rendering': /^pixelated$/,
+    },
   },
   onIgnoreTagAttr: (tag, name, value) => {
     // Allow iframes from acceptable sources


### PR DESCRIPTION
Allows to apply `style` attribute to `<img>` tags with value `image-rendering` set to `pixelated`, which can be useful for people who use pixel art in their READMEs (to demonstrate items, for example).

As asked on Discord:

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/10401817/183349652-f9fa9f5e-9230-43f7-8254-40659e034bf4.png">
  <img alt="Screenshot of Discord message from CodeF53: ‘can we be allowed to do style=&quot;image-rendering: pixelated;&quot; on our &lt;img&gt; elements?
I would like to have a thing that scrolls through all the possible fish without requiring users to download a colossal gif. [Example code snippet]’." src="https://user-images.githubusercontent.com/10401817/183349685-251d20cd-66db-428b-90d6-7de76cd6601f.png">
</picture>

Example code:
```md
<img src="https://i.imgur.com/noESryW.gif" width="128" height="128" style="image-rendering: pixelated;">
```

---

Not sure if any pull requests are accepted to this branch or should go to other branch like `master`, but tell me maybe I'll be able to rebase. Or you can do it yourself, it's a small patch after all.

