### PR TITLE
Add "other launchers" to warning cards

### DIFF
--- a/pages/_type/_id.vue
+++ b/pages/_type/_id.vue
@@ -538,8 +538,9 @@
             >
             which provides instructions on using
             <a href="https://atlauncher.com/about" target="_blank">ATLauncher</a
-            >, <a href="https://multimc.org/" target="_blank">MultiMC</a>, and
-            <a href="https://polymc.org/" target="_blank">PolyMC</a>.
+            >, <a href="https://multimc.org/" target="_blank">MultiMC</a>,
+            <a href="https://polymc.org/" target="_blank">PolyMC</a> and other
+            supported launchers.
           </div>
           <div class="card styled-tabs">
             <nuxt-link

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -222,9 +222,9 @@
         >
         with
         <a href="https://atlauncher.com/about" target="_blank">ATLauncher</a>,
-        <a href="https://multimc.org/" target="_blank">MultiMC</a>, and
-        <a href="https://polymc.org" target="_blank">PolyMC</a>. Pack creators
-        can reference our documentation on
+        <a href="https://multimc.org/" target="_blank">MultiMC</a>,
+        <a href="https://polymc.org" target="_blank">PolyMC</a> and other
+        supported launchers. Pack creators can reference our documentation on
         <a
           href="https://docs.modrinth.com/docs/modpacks/creating_modpacks/"
           target="_blank"


### PR DESCRIPTION
Add "other launchers" because there are many other supported launchers referenced in the documentation, not just MultiMC, PolyMC, and ATLauncher.