### PR TITLE
Add support for GitHub-styled color scheme dependent images

### DIFF
--- a/assets/styles/components.scss
+++ b/assets/styles/components.scss
@@ -184,6 +184,14 @@
     height: auto;
   }
 
+  html:not(.dark-mode, .oled-mode) & img[src$='#gh-dark-mode-only'] {
+    display: none;
+  }
+
+  html:is(.dark-mode, .oled-mode) & img[src$='#gh-light-mode-only'] {
+    display: none;
+  }
+
   pre {
     margin-top: 1rem;
     padding: 14px;


### PR DESCRIPTION
This PR adds support for image URLs suffixed with `#gh-dark-mode-only` and `#gh-light-mode-only`, enhancing compatibility with GitHub README Markdown descriptions.