### PR TITLE
Fixed description * wrap in project create page

### DIFF
--- a/pages/create/project.vue
+++ b/pages/create/project.vue
@@ -1730,6 +1730,10 @@ section.description {
     overflow-y: auto;
     padding: 0 var(--spacing-card-sm);
   }
+
+  label {
+    flex-direction: row;
+  }
 }
 
 .outlined-area {


### PR DESCRIPTION
Asterisk next to description label for the section in project creation page was wrapping at resolutions lower than 1024 pixels, fixed by setting flex-direction: row

before: 
![before image](https://user-images.githubusercontent.com/74706690/186301914-a0057ae7-7527-4f38-a0ef-f2d1ed2b6a5f.png)
after:
![after image](https://user-images.githubusercontent.com/74706690/186301965-6d0e6d26-a872-4597-9a79-b428a9ab92b8.png)
