### PR TITLE
Minor fixes for "See all" link design

### DIFF
--- a/pages/_type/_id.vue
+++ b/pages/_type/_id.vue
@@ -1047,15 +1047,18 @@ export default {
     display: inline-flex;
     align-items: center;
     gap: 3px;
-    padding: 5px 3px 5px 7px; // <- 3px & -> 7px to compensate for chevron
+
     border-radius: 5px;
-    transition: 0.05s all ease-in-out;
+    color: var(--color-link);
   }
 
   .all-link:hover,
-  .all-link:focus {
+  .all-link:focus-visible {
+    color: var(--color-link-hover);
+  }
+
+  .all-link:active {
     color: var(--color-link-active);
-    background: var(--color-card-link-bg);
   }
 }
 


### PR DESCRIPTION
- Now styled as a proper link.
- Change :focus to :focus-visible to avoid link getting stuck in that 'hovered' state because focus does not actually change (it deffo should though, something to fix in the future - should be one fragment change).
- Removed all padding and transition.

<table>
  <tr>
    <th>State</th>
    <th>Light mode</th>
    <th>Dark mode</th>
  </tr>
  <tr>
    <td align="center">Normal</td>
    <td align="center"><img src="https://user-images.githubusercontent.com/10401817/186906103-cbeac783-3df3-4bba-8c2c-2be4ff9582e2.png" alt="Preview of normal link state in light theme." align="center"></td>
    <td align="center"><img src="https://user-images.githubusercontent.com/10401817/186906421-9f57c204-cfca-431c-9a75-3e72e52323d7.png" alt="Preview of normal link state in dark theme." align="center"></td>
  </tr>
  <tr>
    <td align="center">Hovered</td>
    <td align="center"><img src="https://user-images.githubusercontent.com/10401817/186906161-7e721ee3-4484-448e-af6d-971e4984f59c.png" alt="Preview of hovered link state in light theme." align="center"></td>
    <td align="center"><img src="https://user-images.githubusercontent.com/10401817/186906493-fc52026c-8fcd-4397-9fdd-672521ebbb91.png" alt="Preview of hovered link state in dark theme." align="center"></td>
  </tr>
    <td align="center">Active</td>
    <td align="center"><img src="https://user-images.githubusercontent.com/10401817/186906362-16dbcbde-db74-4d6e-ad93-4ae353c6a2d9.png" alt="Preview of active link state in light theme." align="center"></td>
    <td align="center"><img src="https://user-images.githubusercontent.com/10401817/186906555-b581cc97-a3e4-4663-ad5e-1b0d80b38752.png" alt="Preview of active link state in dark theme." align="center"></td>    
  <tr>
  </tr>
</table>


