### PR TITLE
Don't close dropdown when selecting loaders

### DIFF
--- a/pages/_type/_id/version.vue
+++ b/pages/_type/_id/version.vue
@@ -228,7 +228,7 @@
               :multiple="true"
               :searchable="false"
               :show-no-results="false"
-              :close-on-select="true"
+              :close-on-select="false"
               :clear-on-select="false"
               :show-labels="false"
               :limit="6"

--- a/pages/create/project.vue
+++ b/pages/create/project.vue
@@ -452,7 +452,7 @@
                 :multiple="true"
                 :searchable="false"
                 :show-no-results="false"
-                :close-on-select="true"
+                :close-on-select="false"
                 :clear-on-select="false"
                 :show-labels="false"
                 :limit="6"


### PR DESCRIPTION
It is somewhat annoying when the dropdown closes after selecting a loader for a (new) version, as you have to constantly click it again to select additional loaders (i.e. Waterfall if you selected BungeeCord before).

This PR changes this. I hope I changed all the right places...