### PR TITLE
Make the side filter menu always visible in desktop mode.

### DIFF
--- a/pages/search.vue
+++ b/pages/search.vue
@@ -847,6 +847,10 @@ export default {
 }
 
 @media screen and (min-width: 700px) {
+  .filters-card {
+    position: fixed;
+  }
+  
   .search-controls {
     flex-wrap: nowrap;
     flex-direction: row;


### PR DESCRIPTION
Makes the sidebar menu `position: fixed` when in desktop view.

Idea is that it's always visible when scrolling.

![chrome_zMDJFHizBe](https://user-images.githubusercontent.com/10013572/187067827-31cbbd0f-a310-4f6c-811d-1eb88aee33b3.gif)
