### PR TITLE
Fix advertisement label look

### DIFF
--- a/components/ads/Advertisement.vue
+++ b/components/ads/Advertisement.vue
@@ -92,6 +92,8 @@ export default {
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
+
+  position: relative;
 }
 
 #carbonads_1 {
@@ -102,7 +104,6 @@ export default {
 #info-popup {
   overflow: hidden;
   max-width: 100%;
-  position: relative;
 
   font-size: 22px;
   box-sizing: content-box;
@@ -154,7 +155,7 @@ export default {
 .carbon-poweredby,
 .info-popup-poweredby {
   display: block;
-  padding: 6px 8px;
+  padding: 8px 10px;
   background: var(--color-ad-raised);
   text-align: center;
   text-transform: uppercase;
@@ -164,8 +165,9 @@ export default {
   line-height: 1;
   border-top-left-radius: var(--size-rounded-card);
   position: absolute;
-  bottom: 0;
-  right: 0;
+  bottom: -3px;
+  right: -3px;
+  border-bottom-right-radius: var(--size-rounded-card);
 }
 
 @media only screen and (min-width: 320px) and (max-width: 759px) {


### PR DESCRIPTION
Ever since changes for Carbon ads were introduced, the label did not match the appearance of the card, leaving the bottom right corner of the card not round. With more recent changes, where border was added, that became even more apparent - now the border covers the label, which does not look good; this effect only becomes worse when zooming.

This commit attempts to mitigate these issues with the following:

- To fix the border issues, label's absolute position is now calculated from the card wrapper, where the border is applied. This allows label to cover the border for seamless look. That is done by changing position of the card wrapper to relative instead of doing so for the ad contents container.

- The label now tries to take over the border, to do so the bottom and right relative positions have been changed to -3px.

- To account for the position change, the label is now a bit more padded, to make text content of it to look more or less as before, otherwise it would shift a bit. Not sure if the padding changes are accurate, but it does look close to how it looked before.

Screenshot of the page at 175%, no border overlap visible:

![Screenshot](https://user-images.githubusercontent.com/10401817/187087826-63d4ad26-ffd8-441d-8ab3-e755a5bd00ff.jpg)

