### PR TITLE
More reliably detect ad load faults

### DIFF
--- a/components/ads/Advertisement.vue
+++ b/components/ads/Advertisement.vue
@@ -7,6 +7,7 @@
         async
         type="text/javascript"
         src="//cdn.carbonads.com/carbon.js?serve=CEAIKK3N&placement=modrinthcom"
+        @error="onBlocked"
       ></script>
     </client-only>
   </div>
@@ -15,13 +16,8 @@
 <script>
 export default {
   name: 'Advertisement',
-  data() {
-    return {
-      isBlocked: false,
-    }
-  },
-  mounted() {
-    setTimeout(() => {
+  methods: {
+    onBlocked() {
       this.$refs['carbon-script'].outerHTML += `
       <div id="info-popup">
         <span>
@@ -53,7 +49,7 @@ export default {
         </span>
       </div>
       `
-    }, 1000)
+    },
   },
 }
 </script>


### PR DESCRIPTION
Detecting that ad has failed to load with timeout is not accurate and won't work on slow connections. This commit fixes that by changing detection to use 'onerror' event on <script> tag instead, which will be triggered if ad script fails to load due to blocking.