### PR TITLE
Improve project ID display

### DIFF
--- a/components/ui/CopyCode.vue
+++ b/components/ui/CopyCode.vue
@@ -47,6 +47,8 @@ export default {
   display: flex;
   grid-gap: 0.5rem;
   font-family: var(--mono-font);
+  font-size: var(--font-size-sm);
+  margin: 0;
   padding: 0.25rem 0.5rem;
   background-color: var(--color-code-bg);
   width: min-content;

--- a/pages/_type/_id.vue
+++ b/pages/_type/_id.vue
@@ -1124,6 +1124,7 @@ export default {
 
   .info {
     display: flex;
+    align-items: center;
     flex-direction: column;
 
     .top {
@@ -1206,6 +1207,7 @@ export default {
 .infos {
   .info {
     display: flex;
+    align-items: center;
     margin: 0.5rem 0;
 
     .key {


### PR DESCRIPTION
makes the font slightly smaller and removes the base button margin in order to fit in with the overall layout :D

before:

<img width="282" alt="Screenshot 2022-09-24 at 15 02 37" src="https://user-images.githubusercontent.com/70191398/192084816-1e008176-a746-498f-a9f1-1410860339f0.png">

after:

<img width="295" alt="Screenshot 2022-09-24 at 15 02 27" src="https://user-images.githubusercontent.com/70191398/192084821-2f61a222-648c-45a8-9252-059cbe6c469c.png">