### PR TITLE
Fixed favicon not loading on systems with prefered-color-sheme:dark

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -98,19 +98,6 @@ export default {
         rel: 'icon',
         type: 'image/x-icon',
         href: '/favicon.ico',
-        media: '(prefers-color-scheme:no-preference)',
-      },
-      {
-        rel: 'icon',
-        type: 'image/x-icon',
-        href: '/favicon-dark.ico',
-        media: '(prefers-color-scheme:dark)',
-      },
-      {
-        rel: 'icon',
-        type: 'image/x-icon',
-        href: '/favicon.ico',
-        media: '(prefers-color-scheme:light)',
       },
       {
         rel: 'stylesheet',


### PR DESCRIPTION
(This is my first pull request ever, go easy on me! 😅)

The website wasn't displaying a favicon on systems with a system-wide dark theme because line 106 in [`nuxt.config.js`](https://github.com/modrinth/knossos/blob/cd2f2d42a3073c97b4b0a524cf71179c920a924c/nuxt.config.js#L106) was linking to a file that didn't exist: `favicon-dark.ico`.

However, instead of adding this missing file, I just removed the system theme check altogether. I did this because the favicon looks great on a system-wide dark theme so the check seemed very unnecessary, but if you'd rather add the missing `favicon-dark.ico` file instead of pulling this change that's fine too :)

This wasn't an issue a few weeks ago so I imagine someone deleted/moved the missing file and forgot to update `nuxt.config.js`.