### PR TITLE
Persistent version filters

### DIFF
--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -48,6 +48,7 @@
       label="Include snapshots"
       description="Include snapshots"
       :border="false"
+      @input="updateQuery"
     />
     <button
       title="Clear filters"
@@ -94,11 +95,6 @@ export default {
       selectedGameVersions: [],
       selectedLoaders: [],
     }
-  },
-  watch: {
-    showSnapshots() {
-      this.updateQuery()
-    },
   },
   mounted() {
     this.selectedLoaders = this.getQueryAsArray(this.$route.query.loaders)

--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -95,11 +95,17 @@ export default {
       selectedLoaders: [],
     }
   },
+  watch: {
+    showSnapshots() {
+      this.updateQuery()
+    },
+  },
   mounted() {
     this.selectedLoaders = this.getQueryAsArray(this.$route.query.loaders)
     this.selectedGameVersions = this.getQueryAsArray(
       this.$route.query.gameVersions
     )
+    this.showSnapshots = this.$route.query.showSnapshots === 'true'
     this.updateVersionFilters()
   },
   methods: {
@@ -168,6 +174,7 @@ export default {
             ...this.$route.query,
             loaders: this.getAsQuery(this.selectedLoaders),
             gameVersions: this.getAsQuery(this.selectedGameVersions),
+            showSnapshots: this.showSnapshots ? true : undefined,
           },
         })
         .catch(() => {})

--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -97,11 +97,9 @@ export default {
     }
   },
   mounted() {
-    this.selectedLoaders = this.getQueryAsArray(this.$route.query.loaders)
-    this.selectedGameVersions = this.getQueryAsArray(
-      this.$route.query.gameVersions
-    )
-    this.showSnapshots = this.$route.query.showSnapshots === 'true'
+    this.selectedLoaders = this.getQueryAsArray(this.$route.query.l)
+    this.selectedGameVersions = this.getQueryAsArray(this.$route.query.g)
+    this.showSnapshots = this.$route.query.s === 'true'
     this.updateVersionFilters()
   },
   methods: {
@@ -166,9 +164,9 @@ export default {
         .replace({
           query: {
             ...this.$route.query,
-            loaders: this.getAsQuery(this.selectedLoaders),
-            gameVersions: this.getAsQuery(this.selectedGameVersions),
-            showSnapshots: this.showSnapshots ? true : undefined,
+            l: this.getAsQuery(this.selectedLoaders),
+            g: this.getAsQuery(this.selectedGameVersions),
+            s: this.showSnapshots ? true : undefined,
           },
         })
         .catch(() => {})

--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -95,7 +95,23 @@ export default {
       selectedLoaders: [],
     }
   },
+  mounted() {
+    this.selectedLoaders = this.getQueryAsArray(this.$route.query.loaders)
+    this.selectedGameVersions = this.getQueryAsArray(
+      this.$route.query.gameVersions
+    )
+    this.updateVersionFilters()
+  },
   methods: {
+    getQueryAsArray(query) {
+      if (Array.isArray(query)) {
+        return query
+      } else if (typeof query === 'string') {
+        return query.split(',')
+      } else {
+        return []
+      }
+    },
     getValidVersions() {
       if (!this.cachedValidVersions) {
         this.cachedValidVersions = this.$tag.gameVersions.filter((gameVer) =>
@@ -120,6 +136,7 @@ export default {
       return this.cachedValidLoaders
     },
     updateVersionFilters() {
+      this.validateFilters()
       const temp = this.versions.filter(
         (projectVersion) =>
           (this.selectedGameVersions.length === 0 ||
@@ -131,7 +148,35 @@ export default {
               projectVersion.loaders.includes(loader)
             ))
       )
+      this.updateQuery()
       this.$emit('updateVersions', temp)
+    },
+    validateFilters() {
+      this.selectedLoaders = this.selectedLoaders.filter((loader) =>
+        this.getValidLoaders().includes(loader)
+      )
+      this.selectedGameVersions = this.selectedGameVersions.filter((version) =>
+        this.getValidVersions().some(
+          (validVersion) => validVersion.version === version
+        )
+      )
+    },
+    updateQuery() {
+      this.$router
+        .replace({
+          query: {
+            ...this.$route.query,
+            loaders: this.getAsQuery(this.selectedLoaders),
+            gameVersions: this.getAsQuery(this.selectedGameVersions),
+          },
+        })
+        .catch(() => {})
+    },
+    getAsQuery(elements) {
+      if (elements.length === 0) {
+        return undefined
+      }
+      return elements.join(',')
     },
   },
 }

--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -96,7 +96,7 @@ export default {
       selectedLoaders: [],
     }
   },
-  mounted() {
+  fetch() {
     this.selectedLoaders = this.getQueryAsArray(this.$route.query.l)
     this.selectedGameVersions = this.getQueryAsArray(this.$route.query.g)
     this.showSnapshots = this.$route.query.s === 'true'

--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -164,18 +164,18 @@ export default {
         .replace({
           query: {
             ...this.$route.query,
-            l: this.getAsQuery(this.selectedLoaders),
-            g: this.getAsQuery(this.selectedGameVersions),
+            l:
+              this.selectedLoaders.length === 0
+                ? undefined
+                : this.selectedLoaders.join(','),
+            g:
+              this.selectedGameVersions.length === 0
+                ? undefined
+                : this.selectedGameVersions.join(','),
             s: this.showSnapshots ? true : undefined,
           },
         })
         .catch(() => {})
-    },
-    getAsQuery(elements) {
-      if (elements.length === 0) {
-        return undefined
-      }
-      return elements.join(',')
     },
   },
 }

--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -126,7 +126,7 @@ export default {
       }
       return this.cachedValidLoaders
     },
-    updateVersionFilters() {
+    async updateVersionFilters() {
       this.selectedLoaders = this.selectedLoaders.filter((loader) =>
         this.getValidLoaders().includes(loader)
       )
@@ -147,7 +147,7 @@ export default {
               projectVersion.loaders.includes(loader)
             ))
       )
-      this.updateQuery()
+      await this.updateQuery()
       this.$emit('updateVersions', temp)
     },
     async updateQuery() {

--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -138,7 +138,15 @@ export default {
       return this.cachedValidLoaders
     },
     updateVersionFilters() {
-      this.validateFilters()
+      this.selectedLoaders = this.selectedLoaders.filter((loader) =>
+        this.getValidLoaders().includes(loader)
+      )
+      this.selectedGameVersions = this.selectedGameVersions.filter((version) =>
+        this.getValidVersions().some(
+          (validVersion) => validVersion.version === version
+        )
+      )
+
       const temp = this.versions.filter(
         (projectVersion) =>
           (this.selectedGameVersions.length === 0 ||
@@ -152,16 +160,6 @@ export default {
       )
       this.updateQuery()
       this.$emit('updateVersions', temp)
-    },
-    validateFilters() {
-      this.selectedLoaders = this.selectedLoaders.filter((loader) =>
-        this.getValidLoaders().includes(loader)
-      )
-      this.selectedGameVersions = this.selectedGameVersions.filter((version) =>
-        this.getValidVersions().some(
-          (validVersion) => validVersion.version === version
-        )
-      )
     },
     updateQuery() {
       this.$router

--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -97,21 +97,12 @@ export default {
     }
   },
   fetch() {
-    this.selectedLoaders = this.getQueryAsArray(this.$route.query.l)
-    this.selectedGameVersions = this.getQueryAsArray(this.$route.query.g)
+    this.selectedLoaders = this.$route.query.l?.split(',') || []
+    this.selectedGameVersions = this.$route.query.g?.split(',') || []
     this.showSnapshots = this.$route.query.s === 'true'
     this.updateVersionFilters()
   },
   methods: {
-    getQueryAsArray(query) {
-      if (Array.isArray(query)) {
-        return query
-      } else if (typeof query === 'string') {
-        return query.split(',')
-      } else {
-        return []
-      }
-    },
     getValidVersions() {
       if (!this.cachedValidVersions) {
         this.cachedValidVersions = this.$tag.gameVersions.filter((gameVer) =>

--- a/components/ui/VersionFilterControl.vue
+++ b/components/ui/VersionFilterControl.vue
@@ -159,23 +159,21 @@ export default {
       this.updateQuery()
       this.$emit('updateVersions', temp)
     },
-    updateQuery() {
-      this.$router
-        .replace({
-          query: {
-            ...this.$route.query,
-            l:
-              this.selectedLoaders.length === 0
-                ? undefined
-                : this.selectedLoaders.join(','),
-            g:
-              this.selectedGameVersions.length === 0
-                ? undefined
-                : this.selectedGameVersions.join(','),
-            s: this.showSnapshots ? true : undefined,
-          },
-        })
-        .catch(() => {})
+    async updateQuery() {
+      await this.$router.replace({
+        query: {
+          ...this.$route.query,
+          l:
+            this.selectedLoaders.length === 0
+              ? undefined
+              : this.selectedLoaders.join(','),
+          g:
+            this.selectedGameVersions.length === 0
+              ? undefined
+              : this.selectedGameVersions.join(','),
+          s: this.showSnapshots ? true : undefined,
+        },
+      })
     },
   },
 }


### PR DESCRIPTION
This PR adds two query parameters to the *Versions* and *Changelog* sections.
Selecting and unselecting loader and Minecraft versions dynamically updates the query parameters.
Refreshing the page or sharing the link with filters active will automatically apply the filters.
Nonexistent loaders or Minecraft versions will automatically be removed on page load.

https://user-images.githubusercontent.com/13237524/197406455-91a404d9-5bc0-4774-8d25-f2da74c7432e.mp4

This closes #603
