### PR TITLE
Fix Inconsistent button color for adding a gallery image and for adding a new version

### DIFF
--- a/pages/_type/_id/gallery.vue
+++ b/pages/_type/_id/gallery.vue
@@ -91,7 +91,7 @@
         Save changes
       </button>
       <button
-        class="iconified-button"
+        class="brand-button-colors iconified-button"
         @click="
           newGalleryItems.push({
             title: '',


### PR DESCRIPTION
This PR fix Inconsistent button color for adding a gallery image with create version button

![image](https://user-images.githubusercontent.com/40738104/198585798-833d7943-ba2a-45e2-b9df-f53386933a1e.png)


## Before

![image](https://user-images.githubusercontent.com/40738104/198585673-b50494ba-9ba5-4b69-bc1c-0911bd2cf3c4.png)

## After

![image](https://user-images.githubusercontent.com/40738104/198585723-ffb806ae-3eaf-484e-96b1-4737ed23106a.png)
