### PR TITLE
Fix Inconsistent button color for adding a gallery image and for adding a new version

### DIFF
--- a/pages/_type/_id/gallery.vue
+++ b/pages/_type/_id/gallery.vue
@@ -91,7 +91,7 @@
         Save changes
       </button>
       <button
-        class="iconified-button"
+        class="brand-button iconified-button"
         @click="
           newGalleryItems.push({
             title: '',


### PR DESCRIPTION
This PR fix inconsistent button color adding a gallery image compared to new version button.

Related to a [discord thread](https://canary.discord.com/channels/734077874708938864/1033997010044452864/1033997010044452864)

## Before

![image](https://user-images.githubusercontent.com/40738104/198587740-f987a398-6767-4426-aa65-7b07c0df89af.png)

## After

![image](https://user-images.githubusercontent.com/40738104/198587787-ff8891a9-b9bc-4827-8387-81845cda1aa5.png)
