### PR TITLE
Properly reset NavRow animation

### DIFF
--- a/components/ui/NavRow.vue
+++ b/components/ui/NavRow.vue
@@ -98,6 +98,8 @@ export default {
 
       if (this.activeIndex !== -1) {
         this.startAnimation()
+      } else {
+        this.oldIndex = -1
       }
     },
     startAnimation() {


### PR DESCRIPTION
For example, when clicking on e.g. "Mods" the navigation line will appear instantly. Then when clicking on the Modrinth logo, the navigation line will disappear. However, when then clicking on e.g. "Plugins", the line will first appear underneath "Mods" and then move to "Plugins", even though "Mods" was not previously selected. 

This fixes that behavior and causes the line to instantly appear under "Plugins".