### PR TITLE
Remove bottom padding on <details>' last element

### DIFF
--- a/assets/styles/components.scss
+++ b/assets/styles/components.scss
@@ -113,7 +113,14 @@
     border-bottom: 1px solid var(--color-header-underline);
   }
 
-  h1, h2, h3, h4, h5, h6, li, p {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  li,
+  p {
     word-wrap: break-word;
     overflow-wrap: anywhere;
   }
@@ -245,6 +252,10 @@
         border-radius: var(--size-rounded-xs) var(--size-rounded-xs) 0 0;
       }
     }
+
+    > :last-child {
+      margin-bottom: 0 !important;
+    }
   }
 
   > :last-child {
@@ -356,8 +367,8 @@
 }
 
 .button-animation {
-  transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out, transform 0.05s ease-in-out,
-  outline 0.2s ease-in-out;
+  transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out,
+    transform 0.05s ease-in-out, outline 0.2s ease-in-out;
 
   &:active:not(&:disabled) {
     transform: scale(0.95);
@@ -404,30 +415,30 @@ tr.button-transparent {
   background-color: transparent;
   border-radius: var(--size-rounded-sm);
 
-    &:focus-visible:not(&:disabled) > *,
-    &:hover:not(&:disabled) > * {
-      cursor: pointer;
-      filter: brightness(0.85);
-      background-color: var(--color-raised-bg);
-    }
+  &:focus-visible:not(&:disabled) > *,
+  &:hover:not(&:disabled) > * {
+    cursor: pointer;
+    filter: brightness(0.85);
+    background-color: var(--color-raised-bg);
+  }
 
-    &:active:not(&:disabled) > * {
-      filter: brightness(0.8);
-      background-color: var(--color-raised-bg);
-    }
+  &:active:not(&:disabled) > * {
+    filter: brightness(0.8);
+    background-color: var(--color-raised-bg);
+  }
 
-    &:disabled > *,
-    &[disabled] > * {
-      cursor: not-allowed;
-      filter: grayscale(50%);
-      opacity: 0.5;
-      box-shadow: none;
-    }
+  &:disabled > *,
+  &[disabled] > * {
+    cursor: not-allowed;
+    filter: grayscale(50%);
+    opacity: 0.5;
+    box-shadow: none;
+  }
 }
 
 .button-within {
-  transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out, transform 0.05s ease-in-out,
-  outline 0.2s ease-in-out;
+  transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out,
+    transform 0.05s ease-in-out, outline 0.2s ease-in-out;
 
   &:focus-visible:not(&.disabled),
   &:hover:not(&.disabled) {
@@ -578,7 +589,7 @@ tr.button-transparent {
     padding-left: 7px;
     padding-top: 10px;
 
-    transition: background-color .1s ease-in-out;
+    transition: background-color 0.1s ease-in-out;
 
     &:active {
       background: var(--color-button-bg-hover);
@@ -792,7 +803,7 @@ tr.button-transparent {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    grid-gap: .5rem;
+    grid-gap: 0.5rem;
     z-index: 2;
   }
 
@@ -930,7 +941,10 @@ h1 {
   font-weight: bold;
 }
 
-.nuxt-link-exact-active, h1, h2, h3 {
+.nuxt-link-exact-active,
+h1,
+h2,
+h3 {
   .beta-badge {
     background-color: var(--color-button-text-active);
     box-sizing: border-box;
@@ -940,7 +954,8 @@ h1 {
 }
 
 @media (prefers-reduced-motion) {
-  .button-animation, button {
+  .button-animation,
+  button {
     transform: none !important;
   }
 }
@@ -965,7 +980,7 @@ h1 {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    grid-gap: .5rem;
+    grid-gap: 0.5rem;
     z-index: 2;
   }
 
@@ -986,7 +1001,8 @@ h1 {
 }
 
 .universal-labels {
-  label, .label {
+  label,
+  .label {
     .label__title {
       display: block;
       margin-block: var(--spacing-card-md) var(--spacing-card-sm);
@@ -1051,11 +1067,14 @@ h1 {
     width: 15rem;
   }
 
-  input + *, .input-group + * {
+  input + *,
+  .input-group + * {
     margin-block-start: var(--spacing-card-md);
   }
 
-  button, .button, .iconified-button {
+  button,
+  .button,
+  .iconified-button {
     width: fit-content;
   }
 
@@ -1070,12 +1089,14 @@ h1 {
     }
   }
 
-  .adjacent-input, &.adjacent-input {
+  .adjacent-input,
+  &.adjacent-input {
     display: flex;
     flex-direction: row;
     align-items: center;
 
-    .iconified-button, .input-group {
+    .iconified-button,
+    .input-group {
       flex-shrink: 0;
     }
 
@@ -1254,7 +1275,8 @@ button {
     flex-shrink: 0;
   }
 
-  input, textarea {
+  input,
+  textarea {
     border-radius: 0;
     background-color: transparent;
     box-shadow: unset;
@@ -1262,8 +1284,10 @@ button {
     flex-grow: 1;
   }
 
-  &:focus, &:focus-visible, &:focus-within {
-    box-shadow: inset 0 0 0 transparent, 0 0 0 .25rem var(--color-brand-shadow);
+  &:focus,
+  &:focus-visible,
+  &:focus-within {
+    box-shadow: inset 0 0 0 transparent, 0 0 0 0.25rem var(--color-brand-shadow);
     color: var(--color-button-text-active);
   }
 }

--- a/assets/styles/components.scss
+++ b/assets/styles/components.scss
@@ -113,14 +113,7 @@
     border-bottom: 1px solid var(--color-header-underline);
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  li,
-  p {
+  h1, h2, h3, h4, h5, h6, li, p {
     word-wrap: break-word;
     overflow-wrap: anywhere;
   }
@@ -368,7 +361,7 @@
 
 .button-animation {
   transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out, transform 0.05s ease-in-out,
-    outline 0.2s ease-in-out;
+  outline 0.2s ease-in-out;
 
   &:active:not(&:disabled) {
     transform: scale(0.95);
@@ -415,30 +408,30 @@ tr.button-transparent {
   background-color: transparent;
   border-radius: var(--size-rounded-sm);
 
-  &:focus-visible:not(&:disabled)>*,
-  &:hover:not(&:disabled)>* {
-    cursor: pointer;
-    filter: brightness(0.85);
-    background-color: var(--color-raised-bg);
-  }
+    &:focus-visible:not(&:disabled) > *,
+    &:hover:not(&:disabled) > * {
+      cursor: pointer;
+      filter: brightness(0.85);
+      background-color: var(--color-raised-bg);
+    }
 
-  &:active:not(&:disabled)>* {
-    filter: brightness(0.8);
-    background-color: var(--color-raised-bg);
-  }
+    &:active:not(&:disabled) > * {
+      filter: brightness(0.8);
+      background-color: var(--color-raised-bg);
+    }
 
-  &:disabled>*,
-  &[disabled]>* {
-    cursor: not-allowed;
-    filter: grayscale(50%);
-    opacity: 0.5;
-    box-shadow: none;
-  }
+    &:disabled > *,
+    &[disabled] > * {
+      cursor: not-allowed;
+      filter: grayscale(50%);
+      opacity: 0.5;
+      box-shadow: none;
+    }
 }
 
 .button-within {
   transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out, transform 0.05s ease-in-out,
-    outline 0.2s ease-in-out;
+  outline 0.2s ease-in-out;
 
   &:focus-visible:not(&.disabled),
   &:hover:not(&.disabled) {
@@ -941,10 +934,7 @@ h1 {
   font-weight: bold;
 }
 
-.nuxt-link-exact-active,
-h1,
-h2,
-h3 {
+.nuxt-link-exact-active, h1, h2, h3 {
   .beta-badge {
     background-color: var(--color-button-text-active);
     box-sizing: border-box;
@@ -954,9 +944,7 @@ h3 {
 }
 
 @media (prefers-reduced-motion) {
-
-  .button-animation,
-  button {
+  .button-animation, button {
     transform: none !important;
   }
 }
@@ -1002,9 +990,7 @@ h3 {
 }
 
 .universal-labels {
-
-  label,
-  .label {
+  label, .label {
     .label__title {
       display: block;
       margin-block: var(--spacing-card-md) var(--spacing-card-sm);
@@ -1018,7 +1004,6 @@ h3 {
         color: var(--color-badge-red-bg);
       }
     }
-
     .label__description {
       display: block;
       margin-block-end: var(--spacing-card-sm);
@@ -1070,14 +1055,11 @@ h3 {
     width: 15rem;
   }
 
-  input+*,
-  .input-group+* {
+  input + *, .input-group + * {
     margin-block-start: var(--spacing-card-md);
   }
 
-  button,
-  .button,
-  .iconified-button {
+  button, .button, .iconified-button {
     width: fit-content;
   }
 
@@ -1092,14 +1074,12 @@ h3 {
     }
   }
 
-  .adjacent-input,
-  &.adjacent-input {
+  .adjacent-input, &.adjacent-input {
     display: flex;
     flex-direction: row;
     align-items: center;
 
-    .iconified-button,
-    .input-group {
+    .iconified-button, .input-group {
       flex-shrink: 0;
     }
 
@@ -1197,7 +1177,7 @@ button {
       align-items: center;
     }
 
-    >span {
+    > span {
       flex: 2;
       padding-right: var(--spacing-card-lg);
 
@@ -1206,29 +1186,29 @@ button {
       }
     }
 
-    >input,
-    >.multiselect,
-    >.input-group {
+    > input,
+    > .multiselect,
+    > .input-group {
       flex: 3;
       height: fit-content;
     }
 
-    >input[type='button'] {
+    > input[type='button'] {
       height: fit-content;
       flex: 1;
     }
 
-    >input[type='button']:hover {
+    > input[type='button']:hover {
       cursor: pointer;
     }
 
-    >div,
-    >a {
+    > div,
+    > a {
       height: fit-content;
       flex: 1;
     }
 
-    >div:hover {
+    > div:hover {
       cursor: pointer;
     }
   }
@@ -1278,8 +1258,7 @@ button {
     flex-shrink: 0;
   }
 
-  input,
-  textarea {
+  input, textarea {
     border-radius: 0;
     background-color: transparent;
     box-shadow: unset;
@@ -1287,9 +1266,7 @@ button {
     flex-grow: 1;
   }
 
-  &:focus,
-  &:focus-visible,
-  &:focus-within {
+  &:focus, &:focus-visible, &:focus-within {
     box-shadow: inset 0 0 0 transparent, 0 0 0 .25rem var(--color-brand-shadow);
     color: var(--color-button-text-active);
   }

--- a/assets/styles/components.scss
+++ b/assets/styles/components.scss
@@ -251,10 +251,10 @@
         margin-bottom: 0.5rem;
         border-radius: var(--size-rounded-xs) var(--size-rounded-xs) 0 0;
       }
-    }
 
-    > :last-child {
-      margin-bottom: 0 !important;
+      > :last-child:not(summary) {
+        margin-bottom: 0 !important;
+      }
     }
   }
 
@@ -367,8 +367,8 @@
 }
 
 .button-animation {
-  transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out,
-    transform 0.05s ease-in-out, outline 0.2s ease-in-out;
+  transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out, transform 0.05s ease-in-out,
+    outline 0.2s ease-in-out;
 
   &:active:not(&:disabled) {
     transform: scale(0.95);
@@ -415,20 +415,20 @@ tr.button-transparent {
   background-color: transparent;
   border-radius: var(--size-rounded-sm);
 
-  &:focus-visible:not(&:disabled) > *,
-  &:hover:not(&:disabled) > * {
+  &:focus-visible:not(&:disabled)>*,
+  &:hover:not(&:disabled)>* {
     cursor: pointer;
     filter: brightness(0.85);
     background-color: var(--color-raised-bg);
   }
 
-  &:active:not(&:disabled) > * {
+  &:active:not(&:disabled)>* {
     filter: brightness(0.8);
     background-color: var(--color-raised-bg);
   }
 
-  &:disabled > *,
-  &[disabled] > * {
+  &:disabled>*,
+  &[disabled]>* {
     cursor: not-allowed;
     filter: grayscale(50%);
     opacity: 0.5;
@@ -437,8 +437,8 @@ tr.button-transparent {
 }
 
 .button-within {
-  transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out,
-    transform 0.05s ease-in-out, outline 0.2s ease-in-out;
+  transition: opacity 0.5s ease-in-out, filter 0.2s ease-in-out, transform 0.05s ease-in-out,
+    outline 0.2s ease-in-out;
 
   &:focus-visible:not(&.disabled),
   &:hover:not(&.disabled) {
@@ -589,7 +589,7 @@ tr.button-transparent {
     padding-left: 7px;
     padding-top: 10px;
 
-    transition: background-color 0.1s ease-in-out;
+    transition: background-color .1s ease-in-out;
 
     &:active {
       background: var(--color-button-bg-hover);
@@ -803,7 +803,7 @@ tr.button-transparent {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    grid-gap: 0.5rem;
+    grid-gap: .5rem;
     z-index: 2;
   }
 
@@ -954,6 +954,7 @@ h3 {
 }
 
 @media (prefers-reduced-motion) {
+
   .button-animation,
   button {
     transform: none !important;
@@ -980,7 +981,7 @@ h3 {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    grid-gap: 0.5rem;
+    grid-gap: .5rem;
     z-index: 2;
   }
 
@@ -1001,6 +1002,7 @@ h3 {
 }
 
 .universal-labels {
+
   label,
   .label {
     .label__title {
@@ -1016,6 +1018,7 @@ h3 {
         color: var(--color-badge-red-bg);
       }
     }
+
     .label__description {
       display: block;
       margin-block-end: var(--spacing-card-sm);
@@ -1067,8 +1070,8 @@ h3 {
     width: 15rem;
   }
 
-  input + *,
-  .input-group + * {
+  input+*,
+  .input-group+* {
     margin-block-start: var(--spacing-card-md);
   }
 
@@ -1194,7 +1197,7 @@ button {
       align-items: center;
     }
 
-    > span {
+    >span {
       flex: 2;
       padding-right: var(--spacing-card-lg);
 
@@ -1203,29 +1206,29 @@ button {
       }
     }
 
-    > input,
-    > .multiselect,
-    > .input-group {
+    >input,
+    >.multiselect,
+    >.input-group {
       flex: 3;
       height: fit-content;
     }
 
-    > input[type='button'] {
+    >input[type='button'] {
       height: fit-content;
       flex: 1;
     }
 
-    > input[type='button']:hover {
+    >input[type='button']:hover {
       cursor: pointer;
     }
 
-    > div,
-    > a {
+    >div,
+    >a {
       height: fit-content;
       flex: 1;
     }
 
-    > div:hover {
+    >div:hover {
       cursor: pointer;
     }
   }
@@ -1287,7 +1290,7 @@ button {
   &:focus,
   &:focus-visible,
   &:focus-within {
-    box-shadow: inset 0 0 0 transparent, 0 0 0 0.25rem var(--color-brand-shadow);
+    box-shadow: inset 0 0 0 transparent, 0 0 0 .25rem var(--color-brand-shadow);
     color: var(--color-button-text-active);
   }
 }


### PR DESCRIPTION
This removes the empty space that are inside `<details>`'s end:
![Crop of Ok Zoomer's Presets spoiler, with the fix applied](https://user-images.githubusercontent.com/85590273/202582597-02984423-e444-4d7b-9137-df81d20ccce2.png)

The below has been addressed on the refined version of the fix
<details>
<summary>Outdated note</summary>

Do note that if the `<details>` is improperly formatted, then this fix will slightly break it even further, although considered that it's already broken, I don't believe that this outweighs the benefits of the fix;
![Crop of Ok Zoomer's Presets spoiler edited in order to be badly formatted, with the fix applied, making the padding slightly wonky](https://user-images.githubusercontent.com/85590273/202582900-1338a8e3-4674-4792-997c-0de3b0ac3439.png)
</details>

(dev note: why is node.js v16 required when v18 is already LTS ;-;)