### PR TITLE
Re-word "my profile" to "your profile"/"this profile"

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -87,7 +87,7 @@
                   >
                     <div class="title profile-link">
                       <div class="username">@{{ $auth.user.username }}</div>
-                      <div class="prompt">Go to your profile</div>
+                      <div class="prompt">Visit your profile</div>
                     </div>
                   </NuxtLink>
                   <hr class="divider" />

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -87,7 +87,7 @@
                   >
                     <div class="title profile-link">
                       <div class="username">@{{ $auth.user.username }}</div>
-                      <div class="prompt">Go to my profile</div>
+                      <div class="prompt">Go to your profile</div>
                     </div>
                   </NuxtLink>
                   <hr class="divider" />
@@ -228,7 +228,7 @@
               />
               <div class="profile-link">
                 <div class="username">@{{ $auth.user.username }}</div>
-                <div class="prompt">Go to my profile</div>
+                <div class="prompt">Go to your profile</div>
               </div>
             </NuxtLink>
             <button

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -228,7 +228,7 @@
               />
               <div class="profile-link">
                 <div class="username">@{{ $auth.user.username }}</div>
-                <div class="prompt">Go to your profile</div>
+                <div class="prompt">Visit your profile</div>
               </div>
             </NuxtLink>
             <button

--- a/pages/settings/account.vue
+++ b/pages/settings/account.vue
@@ -4,7 +4,7 @@
       ref="modal_confirm"
       title="Are you sure you want to delete your account?"
       description="This will **immediately delete all of your user data and follows**. This will not delete your projects. Deleting your account cannot be reversed.<br><br>If you need help with your account, get support on the [Modrinth Discord](https://discord.gg/EUHuJHt)."
-      proceed-label="Delete my account"
+      proceed-label="Delete this account"
       :confirmation-text="$auth.user.username"
       :has-to-type="true"
       @proceed="deleteAccount"


### PR DESCRIPTION
We're like half asleep and totally open to actual design people picking different wording for these strings, but I'm not super familiar with who's on the designs team and how to get in contact with them so this seemed like a good direct way.

Anyway this pr does [drumroll]

![image](https://user-images.githubusercontent.com/55819817/203234907-ccbcb931-5ec2-401c-913a-9716574d96bc.png)     
becomes 
![image](https://user-images.githubusercontent.com/55819817/203234952-3ff6f0ec-c86c-4646-ada9-8498e994c304.png)     

![image](https://user-images.githubusercontent.com/55819817/203235331-c53aad0c-c04a-4490-9f64-3199d547abb2.png)
becomes
![image](https://user-images.githubusercontent.com/55819817/203235286-fea5a2b1-9212-46a9-ae2d-f1b289c6df27.png)

not super fussed on the second string seeing as we'll never see it but we included it for comprehensiveness

that's it, 