### PR TITLE
Fix notifications fetching

### DIFF
--- a/store/user.js
+++ b/store/user.js
@@ -57,14 +57,14 @@ export const actions = {
   async fetchNotifications({ commit, rootState }) {
     if (rootState.auth.user && rootState.auth.user.id) {
       try {
-        const follows = (
+        const notifications = (
           await this.$axios.get(
             `user/${rootState.auth.user.id}/notifications`,
             rootState.auth.headers
           )
         ).data
 
-        commit('SET_FOLLOWS', follows)
+        commit('SET_NOTIFICATIONS', notifications)
       } catch (err) {
         console.error(err)
       }


### PR DESCRIPTION
In actions of user Vuex store, calling an action to fetch notifications would fetch them correctly, but store them in place of user follows, which resulted in funkiness when switching from notifications to follows page (because Vue would render project cards for notifications data before the actual follows were fetched correctly).