### PR TITLE
Fix modal URL field autofill allowing invalid characters (Issue #785)

### DIFF
--- a/components/ui/ModalCreation.vue
+++ b/components/ui/ModalCreation.vue
@@ -221,7 +221,10 @@ Questions? [Join the Modrinth Discord for support!](https://discord.gg/EUHuJHt)`
     },
     updatedName() {
       if (!this.manualSlug) {
-        this.slug = this.name.toLowerCase().replaceAll(' ', '-')
+        this.slug = this.name
+          .toLowerCase()
+          .replaceAll(' ', '-')
+          .replaceAll(/[^a-zA-Z0-9!@$()`.+,_"-]/g, '')
       }
     },
   },


### PR DESCRIPTION
Fixes modal URL field allowing invalid characters, according to [URL validation Regex in labrinth](https://github.com/modrinth/labrinth/blob/ba28bc94d315c3f6ebb2c71a3daffd8d0317b949/src/util/validate.rs#L8).

![example of URL field working correctly](https://cdn.upload.systems/uploads/VP79SH7q.png)