### PR TITLE
Change 'changelog-item' display to block from flex.

### DIFF
--- a/pages/_type/_id/changelog.vue
+++ b/pages/_type/_id/changelog.vue
@@ -176,7 +176,7 @@ export default {
 
 <style lang="scss" scoped>
 .changelog-item {
-  display: flex;
+  display: block;
   margin-bottom: 1rem;
   position: relative;
   padding-left: 1.8rem;


### PR DESCRIPTION
Change display to block from flex to fix content overflow on the changelog page.