### PR TITLE
Make summaries and bios wrap

### DIFF
--- a/pages/_type/_id.vue
+++ b/pages/_type/_id.vue
@@ -1089,6 +1089,7 @@ export default {
 
   .description {
     line-height: 1.3;
+    overflow-wrap: break-word;
 
     margin-top: var(--spacing-card-sm);
     margin-bottom: 0.5rem;

--- a/pages/user/_id.vue
+++ b/pages/user/_id.vue
@@ -596,6 +596,7 @@ export default {
 
 .bio {
   display: block;
+  overflow-wrap: break-word;
 }
 
 .secondary-stat {


### PR DESCRIPTION
Related to #771 this makes project and profile descriptions wrap very long words or long links.
Unlikely to be seen but for example descriptions that refer to minecraft bugs (https://modrinth.com/mod/entity-collision-fps-fix) are close to overflowing on 1080p screens and do on small screens.
![modrinth](https://user-images.githubusercontent.com/57044042/210636318-eb56333d-cf7d-4c52-8a19-c0d6f19aba21.png)

with fix applied:
![modrinth2](https://user-images.githubusercontent.com/57044042/210636839-0af5af9c-ff39-4e47-a737-0be69e1db7cb.png)

