### PR TITLE
Balance search pages to have view mode-aware max search results

### DIFF
--- a/pages/search.vue
+++ b/pages/search.vue
@@ -702,7 +702,6 @@ export default {
           this.pageCount
         )
       )
-      console.log(newPageNumber)
       this.previousMaxResults = this.maxResults
       await this.onSearchChange(newPageNumber)
     },

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -307,7 +307,9 @@
               v-model="maxResults"
               placeholder="Select one"
               class="labeled-control__control"
-              :options="[5, 10, 15, 20, 50, 100]"
+              :options="
+                maxResultsForView[$cosmetics.searchDisplayMode[projectType.id]]
+              "
               :searchable="false"
               :close-on-select="true"
               :show-labels="false"
@@ -473,6 +475,12 @@ export default {
 
       maxResults: 20,
 
+      maxResultsForView: {
+        list: [5, 10, 15, 20, 50, 100],
+        grid: [6, 12, 18, 24, 48, 96],
+        gallery: [6, 10, 16, 20, 50, 100],
+      },
+
       sidebarMenuOpen: false,
       showAllLoaders: false,
 
@@ -521,11 +529,13 @@ export default {
           break
       }
     }
+
     if (this.$route.query.m) {
       this.maxResults = this.$route.query.m
     }
-    if (this.$route.query.o)
+    if (this.$route.query.o) {
       this.currentPage = Math.ceil(this.$route.query.o / this.maxResults) + 1
+    }
 
     this.projectType = this.$tag.projectTypes.find(
       (x) => x.id === this.$route.name.substring(0, this.$route.name.length - 1)
@@ -600,6 +610,8 @@ export default {
         await this.clearFilters()
 
         this.isLoading = false
+
+        this.setClosestMaxResults()
       },
     },
   },
@@ -841,6 +853,21 @@ export default {
         mode: newValue,
         $cookies: this.$cookies,
       })
+      this.setClosestMaxResults()
+    },
+    setClosestMaxResults() {
+      const view = this.$cosmetics.searchDisplayMode[this.projectType.id]
+      const maxResultsOptions = this.maxResultsForView[view] ?? [20]
+      const currentMax = this.maxResults
+      console.log(maxResultsOptions)
+      console.log(currentMax)
+      if (!maxResultsOptions.includes(currentMax)) {
+        this.maxResults = maxResultsOptions.reduce(function (prev, curr) {
+          return Math.abs(curr - currentMax) <= Math.abs(prev - currentMax)
+            ? curr
+            : prev
+        })
+      }
     },
   },
 }

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -859,8 +859,6 @@ export default {
       const view = this.$cosmetics.searchDisplayMode[this.projectType.id]
       const maxResultsOptions = this.maxResultsForView[view] ?? [20]
       const currentMax = this.maxResults
-      console.log(maxResultsOptions)
-      console.log(currentMax)
       if (!maxResultsOptions.includes(currentMax)) {
         this.maxResults = maxResultsOptions.reduce(function (prev, curr) {
           return Math.abs(curr - currentMax) <= Math.abs(prev - currentMax)

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -314,7 +314,7 @@
               :close-on-select="true"
               :show-labels="false"
               :allow-empty="false"
-              @input="onSearchChange(currentPage)"
+              @input="onMaxResultsChange(currentPage)"
             />
           </div>
           <button
@@ -474,6 +474,7 @@ export default {
       sortType: { display: 'Relevance', name: 'relevance' },
 
       maxResults: 20,
+      previousMaxResults: 20,
 
       maxResultsForView: {
         list: [5, 10, 15, 20, 50, 100],
@@ -519,7 +520,7 @@ export default {
           this.sortType.display = 'Downloads'
           break
         case 'newest':
-          this.sortType.display = 'Recently created'
+          this.sortType.display = 'Recently published'
           break
         case 'updated':
           this.sortType.display = 'Recently updated'
@@ -689,6 +690,20 @@ export default {
     async onSearchChangeToTop(newPageNumber) {
       if (process.client) window.scrollTo({ top: 0, behavior: 'smooth' })
 
+      await this.onSearchChange(newPageNumber)
+    },
+    async onMaxResultsChange(newPageNumber) {
+      newPageNumber = Math.max(
+        1,
+        Math.min(
+          Math.floor(
+            newPageNumber / (this.maxResults / this.previousMaxResults)
+          ),
+          this.pageCount
+        )
+      )
+      console.log(newPageNumber)
+      this.previousMaxResults = this.maxResults
       await this.onSearchChange(newPageNumber)
     },
     async onSearchChange(newPageNumber) {


### PR DESCRIPTION
On grid mode, it will have these options which are even multiples of 3:
![image](https://user-images.githubusercontent.com/6166773/211471448-98a8389d-7b10-413b-a9f2-07332c5d4371.png)

While gallery mode has all even options:
![image](https://user-images.githubusercontent.com/6166773/211471514-8db58fc9-830c-466f-a9ea-b1efadf25532.png)

Also fixes #829
