### PR TITLE
Remove numbers at the start of slugs when converting to mod ID

### DIFF
--- a/plugins/fileUtils.js
+++ b/plugins/fileUtils.js
@@ -363,6 +363,7 @@ export const createDataPackVersion = async function (
   const newSlug = `${project.slug
     .replace('-', '_')
     .replace(/\W/g, '')
+    .replace(/^(\d+)(\D+)$/g, '$2')
     .substring(0, 63)}_mr`
 
   const iconPath = `${project.slug}_pack.png`

--- a/plugins/fileUtils.js
+++ b/plugins/fileUtils.js
@@ -360,10 +360,12 @@ export const createDataPackVersion = async function (
     ? version.version_number
     : `1-${version.version_number}`
 
+  const targetStartingDigitsRegex = /^(\d+)(\D+)$/g
   const newSlug = `${project.slug
     .replace('-', '_')
     .replace(/\W/g, '')
-    .replace(/^(\d+)(\D+)$/g, '$2')
+    .replace(targetStartingDigitsRegex, '$2')
+    .replace(/^(\d+)$/g, project.id.replace(targetStartingDigitsRegex, '$2'))
     .substring(0, 63)}_mr`
 
   const iconPath = `${project.slug}_pack.png`


### PR DESCRIPTION
Removes any leading numbers from the mod ID that is generated from the project's slug for data pack -> mod conversion

Fixes #845