### PR TITLE
Fix custom license erroring with spaces

### DIFF
--- a/pages/_type/_id/settings/license.vue
+++ b/pages/_type/_id/settings/license.vue
@@ -186,8 +186,8 @@ export default {
       id += this.license.short
       if (this.license.requiresOnlyOrLater)
         id += this.allowOrLater ? '-or-later' : '-only'
-      if (this.nonSpdxLicense && this.license.short === 'Custom')
-        id.replaceAll(' ', '-')
+      if (this.nonSpdxLicense && this.license.friendly === 'Custom')
+        id = id.replaceAll(' ', '-')
       return id
     },
     defaultLicenses() {


### PR DESCRIPTION
Pretty sure this was the intended functionality of this, it'll replace spaces in custom license names with `-` for the ID