### PR TITLE
GitHub Actions: Use Node 16 to build Knossos

### DIFF
--- a/.github/workflows/nuxt.yml
+++ b/.github/workflows/nuxt.yml
@@ -2,28 +2,28 @@ name: Nuxt CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: 16
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
+          # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-node-
       - name: Install dependencies
         run: npm ci
       - name: Build Knossos


### PR DESCRIPTION
This is the last version Nuxt 2 supports.