### PR TITLE
Remove .zip from possible modpack versions

### DIFF
--- a/plugins/fileUtils.js
+++ b/plugins/fileUtils.js
@@ -41,7 +41,7 @@ export const acceptFileFromProjectType = (projectType) => {
     case 'datapack':
       return '.zip,application/zip'
     case 'modpack':
-      return '.mrpack,application/x-modrinth-modpack+zip,application/zip'
+      return '.mrpack,application/x-modrinth-modpack+zip'
     default:
       return '*'
   }


### PR DESCRIPTION
This format isn't allowed in Labrinth, and shouldn't be shown as a option in the file picker

https://github.com/modrinth/labrinth/blob/df3aeed2910cf11d39fe0dbe1a05f411e0541397/src/validate/modpack.rs#L15