### PR TITLE
Recalculate changelog deduplication when the filters change

### DIFF
--- a/pages/_type/_id/changelog.vue
+++ b/pages/_type/_id/changelog.vue
@@ -98,13 +98,14 @@ export default {
   },
   data() {
     return {
-      filteredVersions: this.versions,
+      filteredVersions: this.$calculateDuplicates(this.versions),
       currentPage: 1,
     }
   },
   fetch() {
-    if (this.$route.query.page)
+    if (this.$route.query.page) {
       this.currentPage = parseInt(this.$route.query.page)
+    }
   },
   head() {
     const title = `${this.project.title} - Changelog`
@@ -154,7 +155,7 @@ export default {
       }
     },
     updateVersions(updatedVersions) {
-      this.filteredVersions = updatedVersions
+      this.filteredVersions = this.$calculateDuplicates(updatedVersions)
     },
   },
   auth: false,

--- a/plugins/shorthands.js
+++ b/plugins/shorthands.js
@@ -32,6 +32,20 @@ export default (ctx, inject) => {
   inject('formatCategory', formatCategory)
   inject('formatCategoryHeader', formatCategoryHeader)
   inject('formatProjectStatus', formatProjectStatus)
+  inject('calculateDuplicates', (versions) =>
+    versions.map((version, index) => {
+      const nextVersion = versions[index + 1]
+      if (
+        nextVersion &&
+        version.changelog &&
+        nextVersion.changelog === version.changelog
+      ) {
+        return { duplicate: true, ...version }
+      } else {
+        return { duplicate: false, ...version }
+      }
+    })
+  )
   inject('computeVersions', (versions) => {
     const visitedVersions = []
     const returnVersions = []
@@ -52,18 +66,6 @@ export default (ctx, inject) => {
 
     return returnVersions
       .reverse()
-      .map((version, index) => {
-        const nextVersion = returnVersions[index + 1]
-        if (
-          nextVersion &&
-          version.changelog &&
-          nextVersion.changelog === version.changelog
-        ) {
-          return { duplicate: true, ...version }
-        } else {
-          return { duplicate: false, ...version }
-        }
-      })
       .sort(
         (a, b) => ctx.$dayjs(b.date_published) - ctx.$dayjs(a.date_published)
       )


### PR DESCRIPTION
Previously, if let's say you have a fabric and forge version and the forge version was the duplicate, if you changed it to filter by forge, the changelogs would not show because fabric was the non-duplicate, which is no longer shown.