### PR TITLE
 Set layout display to flow-root (fixes #958)

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -500,7 +500,7 @@ export default defineNuxtComponent({
 .layout {
   min-height: 100vh;
   background-color: var(--color-bg);
-  display: block;
+  display: flow-root;
 
   @media screen and (min-width: 1024px) {
     min-height: calc(100vh - var(--spacing-card-bg));


### PR DESCRIPTION
This prevents pages from overflowing by default. Previously, margins from children of containers with `.layout` would apply outside of the body instead of within. (Fixes #958)