### PR TITLE
Fix modal text getting blurred from transforms in chromium on some devices (fix #962)

### DIFF
--- a/components/ui/Modal.vue
+++ b/components/ui/Modal.vue
@@ -8,15 +8,17 @@
       class="modal-overlay"
       @click="hide"
     />
-    <div class="modal-body" :class="{ shown: shown }">
-      <div v-if="header" class="header">
-        <h1>{{ header }}</h1>
-        <button class="iconified-button icon-only transparent" @click="hide">
-          <CrossIcon />
-        </button>
-      </div>
-      <div class="content">
-        <slot />
+    <div class="modal-container" :class="{ shown }">
+      <div class="modal-body">
+        <div v-if="header" class="header">
+          <h1>{{ header }}</h1>
+          <button class="iconified-button icon-only transparent" @click="hide">
+            <CrossIcon />
+          </button>
+        </div>
+        <div class="content">
+          <slot />
+        </div>
       </div>
     </div>
   </div>
@@ -60,7 +62,6 @@ export default {
   width: 100%;
   height: 100%;
   z-index: 20;
-
   transition: all 0.3s ease-in-out;
 
   &.shown {
@@ -75,46 +76,61 @@ export default {
   }
 }
 
-.modal-body {
+.modal-container {
   position: fixed;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   z-index: 21;
-  box-shadow: var(--shadow-raised), var(--shadow-inset);
-  border-radius: var(--size-rounded-lg);
-  max-height: calc(100% - 2 * var(--spacing-card-bg));
-  overflow-y: auto;
-  width: 600px;
+  visibility: hidden;
+  pointer-events: none;
 
-  .header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background-color: var(--color-bg);
-    padding: var(--spacing-card-md) var(--spacing-card-lg);
-
-    h1 {
-      font-size: 1.25rem;
+  &.shown {
+    visibility: visible;
+    .modal-body {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
     }
   }
 
-  .content {
-    background-color: var(--color-raised-bg);
-  }
+  .modal-body {
+    position: fixed;
+    box-shadow: var(--shadow-raised), var(--shadow-inset);
+    border-radius: var(--size-rounded-lg);
+    max-height: calc(100% - 2 * var(--spacing-card-bg));
+    overflow-y: auto;
+    width: 600px;
+    pointer-events: auto;
 
-  top: calc(100% + 400px);
-  visibility: hidden;
-  opacity: 0;
-  transition: all 0.25s ease-in-out;
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background-color: var(--color-bg);
+      padding: var(--spacing-card-md) var(--spacing-card-lg);
 
-  &.shown {
-    opacity: 1;
-    visibility: visible;
-    top: 50%;
-  }
+      h1 {
+        font-size: 1.25rem;
+      }
+    }
 
-  @media screen and (max-width: 650px) {
-    width: calc(100% - 2 * var(--spacing-card-bg));
+    .content {
+      background-color: var(--color-raised-bg);
+    }
+
+    transform: translateY(50vh);
+    visibility: hidden;
+    opacity: 0;
+    transition: all 0.25s ease-in-out;
+
+    @media screen and (max-width: 650px) {
+      width: calc(100% - 2 * var(--spacing-card-bg));
+    }
   }
 }
 </style>


### PR DESCRIPTION
Fixes #962

This bug was caused by issues with using transform on text elements. I opted to use a flexbox container to
position the modal in the center without using transforms, which eliminates this issue. From the testing I've done
so far, this produces an identical effect, just without the blurring.

Old version:
![image](https://user-images.githubusercontent.com/17936976/215591646-9c55e228-985c-445a-9633-f7e6bdf8956d.png)

Fixed version:
![image](https://user-images.githubusercontent.com/17936976/215591708-cd7aad3b-47b4-43e1-b9b1-4fdf321237cc.png)

