### PR TITLE
Make position of the "no results" text on grid/gallery views consistent (fixes #963)

### DIFF
--- a/pages/search/[type].vue
+++ b/pages/search/[type].vue
@@ -947,7 +947,7 @@ export default defineNuxtComponent({
 
 .no-results {
   text-align: center;
-  padding-top: var(--spacing-card-md);
+  display: flow-root;
 }
 
 @media screen and (min-width: 750px) {

--- a/pages/search/[type].vue
+++ b/pages/search/[type].vue
@@ -302,6 +302,9 @@
         @switch-page="onSearchChange"
       />
       <div class="search-results-container">
+        <div v-if="results && results.length === 0" class="no-results">
+          <p>No results found for your query!</p>
+        </div>
         <div
           id="search-results"
           class="project-list"
@@ -332,9 +335,6 @@
             :hide-loaders="['resourcepack', 'datapack'].includes(projectType.id)"
             :color="result.color"
           />
-          <div v-if="results && results.length === 0" class="no-results">
-            <p>No results found for your query!</p>
-          </div>
         </div>
       </div>
       <pagination
@@ -947,6 +947,7 @@ export default defineNuxtComponent({
 
 .no-results {
   text-align: center;
+  padding-top: var(--spacing-card-md);
 }
 
 @media screen and (min-width: 750px) {


### PR DESCRIPTION
Fixes #963 

This PR move the "No results for your query" text outside of the grid so that it is consistently centered.

List view:
<img width="977" alt="CleanShot 2023-01-30 at 15 40 13@2x" src="https://user-images.githubusercontent.com/17936976/215621772-aad4911b-e861-439b-b8e6-0b68f66f1e41.png">

Current grid view: 
<img width="964" alt="CleanShot 2023-01-30 at 15 41 36@2x" src="https://user-images.githubusercontent.com/17936976/215621846-db5840e9-dc34-461e-b537-57d3c17ebad1.png">

New grid view: 
<img width="959" alt="CleanShot 2023-01-30 at 15 51 41@2x" src="https://user-images.githubusercontent.com/17936976/215623111-80dac407-5bdd-49ef-a45d-e9415ea5bd43.png">


(The same applies for the gallery view as well)
