### PR TITLE
Adjust dropdown layout shift and placeholder line height (Fixes #969)

### DIFF
--- a/assets/styles/components.scss
+++ b/assets/styles/components.scss
@@ -71,9 +71,10 @@
     .multiselect__placeholder {
       color: var(--color-button-text);
       margin-left: 8px;
+      margin-bottom: 8px;
       opacity: 0.6;
       font-size: 16px;
-      line-height: 20px;
+      line-height: 16px;
     }
   }
 
@@ -1056,9 +1057,10 @@ tr.button-transparent {
     .multiselect__placeholder {
       color: var(--color-button-text);
       margin-left: 8px;
+      margin-bottom: 8px;
       opacity: 0.6;
       font-size: 16px;
-      line-height: 20px;
+      line-height: 16px;
     }
   }
 


### PR DESCRIPTION
Fixes #969

The dropdown component uses a span to display placeholder text until it is focused, then it uses a normal input placeholder.
The margin on the span element was 10px, and the input had 8px, causing a layout shift whenever the multiselect was focused. The placeholder also had a line-height of 20px which made the text appear off-center, so I adjusted it to 16px.

