### PR TITLE
fix(creator-section): border radius on icons not aligning with bg

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1088,7 +1088,7 @@ export default {
         height: 4rem;
         background: #020305;
         box-shadow: 2px 2px 12px rgba(0, 0, 0, 0.16), inset 2px 2px 32px #393d5e;
-        border-radius: 0.75rem;
+        border-radius: 1rem;
 
         svg {
           width: 2rem;


### PR DESCRIPTION
**Description:**
Aligns the icon border radius with the gradient-border border-radius: `1rem`.

**Media:**
Before:
![image](https://user-images.githubusercontent.com/32039051/219775117-60b99ab6-0e5b-49e2-bb98-14a02a9261b7.png)

After:
![image](https://user-images.githubusercontent.com/32039051/219775202-e1ca547a-69d0-434d-abc5-356575cc566d.png)

_Note Images were taken from issue_


Closes: modrinth/code#1668 