### PR TITLE
Changes demo-search height to be min-height.

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1222,9 +1222,10 @@ const [
             font-size: 1.5rem;
           }
         }
+
         .blob-demonstration {
           .demo-search {
-            height: 37.5rem;
+            min-height: 37.5rem;
           }
 
           .launcher-view {


### PR DESCRIPTION
Fixes #893 

With height being changed to min-height, the container can resize as necessary.