### PR TITLE
Adds media query style to prevent Report button from overlapping username.

### DIFF
--- a/pages/user/[id].vue
+++ b/pages/user/[id].vue
@@ -528,4 +528,10 @@ export default defineNuxtComponent({
 .textarea-wrapper {
   height: 10rem;
 }
+
+@media (max-width: 400px) {
+  .sidebar {
+    padding-top: 3rem;
+  }
+}
 </style>


### PR DESCRIPTION
Resolves #914 

Media query will push username down once Report button is somewhat close to it. I chose 400px because the Report button was already overlapping Geometrically's username by 400.