### PR TITLE
See all versions will navigate to versions#all-versions.

### DIFF
--- a/pages/[type]/[id].vue
+++ b/pages/[type]/[id].vue
@@ -442,7 +442,7 @@
             <h2 class="card-header">Featured versions</h2>
             <nuxt-link
               v-if="versions.length > 0 || currentMember"
-              :to="`/${project.project_type}/${project.slug ? project.slug : project.id}/versions`"
+              :to="`/${project.project_type}/${project.slug ? project.slug : project.id}/versions#all-versions`"
               class="goto-link"
             >
               See all

--- a/pages/[type]/[id].vue
+++ b/pages/[type]/[id].vue
@@ -442,7 +442,9 @@
             <h2 class="card-header">Featured versions</h2>
             <nuxt-link
               v-if="versions.length > 0 || currentMember"
-              :to="`/${project.project_type}/${project.slug ? project.slug : project.id}/versions#all-versions`"
+              :to="`/${project.project_type}/${
+                project.slug ? project.slug : project.id
+              }/versions#all-versions`"
               class="goto-link"
             >
               See all

--- a/pages/[type]/[id]/versions.vue
+++ b/pages/[type]/[id]/versions.vue
@@ -30,7 +30,7 @@
       :link-function="(page) => `?page=${page}`"
       @switch-page="switchPage"
     />
-    <div v-if="filteredVersions.length > 0" class="universal-card all-versions">
+    <div v-if="filteredVersions.length > 0" id="all-versions" class="universal-card all-versions">
       <div class="header">
         <div />
         <div>Version</div>


### PR DESCRIPTION
Closes #949.

Since the button does a router push, the page just instantly loads at all-versions. A more clever solution can be concocted later, but this should at least make using the button less egregious when on the versions page.