### PR TITLE
 fix(xss): allow any query parameters in youtube embed, ported from #1001

### DIFF
--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -44,7 +44,7 @@ export const configuredXss = new xss.FilterXSS({
                 // case where its ?followed=by&another=queryParam
                 if (index + remove.length < value.length && value.charAt(index + remove.length) === '&') {
                   value = value.replace(`${remove}&`, '');
-                } else {
+                } else if (index + remove.length >= value.length) {
                   value = value.replace(`?${remove}`, '');
                 }
               } else {

--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -38,14 +38,14 @@ export const configuredXss = new xss.FilterXSS({
           for (const remove of source.remove) {
             let index = value.indexOf(remove);
             do {
-              if (index - 1 > 0 && value.charAt(index - 1)) === '?') {
+              if (index - 1 > 0 && value.charAt(index - 1) === '?') {
                 // need to watch out for two things
                 // case where its ?stand=alone
                 // case where its ?followed=by&another=queryParam
-                if (index + remove.length < remove.length && value.charAt(index + remove.length) === '&') {
-                  value = value.replace(`{remove}&`, '');
+                if (index + remove.length < value.length && value.charAt(index + remove.length) === '&') {
+                  value = value.replace(`${remove}&`, '');
                 } else {
-                  value = value.replace(`?{remove}`, '');
+                  value = value.replace(`?${remove}`, '');
                 }
               } else {
                 value = value.replaceAll(`&${remove}`, ''); // can safely be removed

--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -36,14 +36,22 @@ export const configuredXss = new xss.FilterXSS({
       for (const source of allowedSources) {
         if (source.regex.test(value)) {
           for (const remove of source.remove) {
-            const index = value.indexOf(remove);
-            if (index !== -1) {
-              if (index - 1 > 0 && value.charAt(index - 1)) === "?") {
-                
+            let index = value.indexOf(remove);
+            do {
+              if (index - 1 > 0 && value.charAt(index - 1)) === '?') {
+                // need to watch out for two things
+                // case where its ?stand=alone
+                // case where its ?followed=by&another=queryParam
+                if (index + remove.length < remove.length && value.charAt(index + remove.length) === '&') {
+                  value = value.replace(`{remove}&`, '');
+                } else {
+                  value = value.replace(`?{remove}`, '');
+                }
               } else {
-                value = value.replaceAll(`&${remove}`, ""); // can safely be removed
+                value = value.replaceAll(`&${remove}`, ''); // can safely be removed
               }
-            }
+              index = value.indexOf(remove);
+            } while (index !== -1);
           }
           return name + '="' + xss.escapeAttrValue(value) + '"'
         }

--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -28,15 +28,22 @@ export const configuredXss = new xss.FilterXSS({
       const allowedSources = [
         {
           regex:
-            /^https?:\/\/(www\.)?youtube(-nocookie)?\.com\/embed\/[a-zA-Z0-9_-]{11}(\?&autoplay=[0-1]{1})?$/,
-          remove: ['&autoplay=1'], // Prevents autoplay
+            /^https?:\/\/(www\.)?youtube(-nocookie)?\.com\/embed\/[a-zA-Z0-9_-]{11}((&|\?)\w+=\w+)*$/,
+          remove: ['autoplay=1'], // Prevents autoplay
         },
       ]
 
       for (const source of allowedSources) {
         if (source.regex.test(value)) {
           for (const remove of source.remove) {
-            value = value.replace(remove, '')
+            const index = value.indexOf(remove);
+            if (index !== -1) {
+              if (index - 1 > 0 && value.charAt(index - 1)) === "?") {
+                
+              } else {
+                value = value.replaceAll(`&${remove}`, ""); // can safely be removed
+              }
+            }
           }
           return name + '="' + xss.escapeAttrValue(value) + '"'
         }


### PR DESCRIPTION
**Description:**
(This has been copied from #1001 verbatim)
The previous regex ONLY allowed for youtube embeds to have the query param autoplay, meaning when embedding youtube videos, people would have to manually sort through their src url to remove unwanted properties. (This is also not wanted, since the start is a very useful prop for these types of videos, if the real tutorial/showcase begins 2 minutes in.

The following regex works for any query parameters.
^https?:\/\/(www\.)?youtube(-nocookie)?\.com\/embed\/[a-zA-Z0-9_-]{11}(\?(&?\w+=(\w|\d)+)+)?$
(This setup then works as a default blacklist approach, where any non-wanted query parameters should be added to the remove section).
Simply due to the nature of regex, that requires the position of strings to match, or just matching 3 parameters would end up in a very clonky a,b,c | a,c,b | c,a,b | etc... (9 options total)

New changes in this PR are:
- Fixing the autoplay remover
- Modifying the regex to avoid a ReDOS