### PR TITLE
Fix disabled css selector Closes #1042

### DIFF
--- a/assets/styles/components.scss
+++ b/assets/styles/components.scss
@@ -778,7 +778,7 @@
   }
 
   &:disabled,
-  &[disabled] {
+  &[disabled="true"] {
     cursor: not-allowed;
     filter: grayscale(50%);
     opacity: 0.5;
@@ -816,7 +816,7 @@ tr.button-transparent {
   }
 
   &:disabled > *,
-  &[disabled] > * {
+  &[disabled="true"] > * {
     cursor: not-allowed;
     filter: grayscale(50%);
     opacity: 0.5;
@@ -849,7 +849,7 @@ tr.button-transparent {
     box-shadow: none;
 
     &disabled,
-    &[disabled] {
+    &[disabled="true"] {
       cursor: not-allowed;
       box-shadow: none;
     }

--- a/assets/styles/components.scss
+++ b/assets/styles/components.scss
@@ -778,7 +778,7 @@
   }
 
   &:disabled,
-  &[disabled="true"] {
+  &[disabled='true'] {
     cursor: not-allowed;
     filter: grayscale(50%);
     opacity: 0.5;
@@ -816,7 +816,7 @@ tr.button-transparent {
   }
 
   &:disabled > *,
-  &[disabled="true"] > * {
+  &[disabled='true'] > * {
     cursor: not-allowed;
     filter: grayscale(50%);
     opacity: 0.5;
@@ -849,7 +849,7 @@ tr.button-transparent {
     box-shadow: none;
 
     &disabled,
-    &[disabled="true"] {
+    &[disabled='true'] {
       cursor: not-allowed;
       box-shadow: none;
     }

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -399,7 +399,7 @@ textarea {
   }
 
   &:disabled,
-  &[disabled] {
+  &[disabled="true"] {
     opacity: 0.6;
     pointer-events: none;
     cursor: not-allowed;

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -399,7 +399,7 @@ textarea {
   }
 
   &:disabled,
-  &[disabled="true"] {
+  &[disabled='true'] {
     opacity: 0.6;
     pointer-events: none;
     cursor: not-allowed;

--- a/components/ui/FileInput.vue
+++ b/components/ui/FileInput.vue
@@ -1,8 +1,19 @@
 <template>
-  <label :class="{ 'long-style': longStyle }" :disabled="disabled" @drop.prevent="handleDrop" @dragover.prevent>
+  <label
+    :class="{ 'long-style': longStyle }"
+    :disabled="disabled"
+    @drop.prevent="handleDrop"
+    @dragover.prevent
+  >
     <slot />
     {{ prompt }}
-    <input type="file" :multiple="multiple" :accept="accept" :disabled="disabled" @change="handleChange" />
+    <input
+      type="file"
+      :multiple="multiple"
+      :accept="accept"
+      :disabled="disabled"
+      @change="handleChange"
+    />
   </label>
 </template>
 

--- a/components/ui/FileInput.vue
+++ b/components/ui/FileInput.vue
@@ -1,8 +1,8 @@
 <template>
-  <label :class="{ 'long-style': longStyle }" @drop.prevent="handleDrop" @dragover.prevent>
+  <label :class="{ 'long-style': longStyle }" :disabled="disabled" @drop.prevent="handleDrop" @dragover.prevent>
     <slot />
     {{ prompt }}
-    <input type="file" :multiple="multiple" :accept="accept" @change="handleChange" />
+    <input type="file" :multiple="multiple" :accept="accept" :disabled="disabled" @change="handleChange" />
   </label>
 </template>
 
@@ -40,6 +40,10 @@ export default {
       default: false,
     },
     longStyle: {
+      type: Boolean,
+      default: false,
+    },
+    disabled: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
This seems to fix #1042. I did notice an additional bug, which is that the cursor does not change to `not-allowed` when disabled. This seems to be a browser bug that I guess was just never fixed? https://stackoverflow.com/questions/1537223/change-cursor-type-on-input-type-file