### PR TITLE
Fix project type in Dashboard & settings URLs Closes #1066

### DIFF
--- a/pages/[type]/[id]/settings/index.vue
+++ b/pages/[type]/[id]/settings/index.vue
@@ -64,7 +64,9 @@
         <span class="label__title">URL</span>
       </label>
       <div class="text-input-wrapper">
-        <div class="text-input-wrapper__before">https://modrinth.com/mod/</div>
+        <div class="text-input-wrapper__before">
+          https://modrinth.com/{{ $getProjectTypeForUrl(project.project_type, project.loaders) }}/
+        </div>
         <input
           id="project-slug"
           v-model="slug"

--- a/pages/dashboard/projects.vue
+++ b/pages/dashboard/projects.vue
@@ -229,7 +229,12 @@
               />
             </div>
             <div>
-              <nuxt-link tabindex="-1" :to="`/${project.project_type}/${project.slug}`">
+              <nuxt-link
+                tabindex="-1"
+                :to="`/${$getProjectTypeForUrl(project.project_type, project.loaders)}/${
+                  project.slug
+                }`"
+              >
                 <Avatar
                   :src="project.icon_url"
                   aria-hidden="true"
@@ -248,7 +253,9 @@
 
                 <nuxt-link
                   class="hover-link wrap-as-needed"
-                  :to="`/${project.project_type}/${project.slug}`"
+                  :to="`/${$getProjectTypeForUrl(project.project_type, project.loaders)}/${
+                    project.slug
+                  }`"
                 >
                   {{ project.title }}
                 </nuxt-link>
@@ -270,7 +277,9 @@
             <div>
               <nuxt-link
                 class="square-button"
-                :to="`/${project.project_type}/${project.slug}/settings`"
+                :to="`/${$getProjectTypeForUrl(project.project_type, project.loaders)}/${
+                  project.slug
+                }/settings`"
               >
                 <SettingsIcon />
               </nuxt-link>


### PR DESCRIPTION
Fixes the projects page in dashboard linking to the actual project type instead of the inferred one, fix display of project type in slug field Closes #1066 