### PR TITLE
Add indicators for visibility on project settings page

### DIFF
--- a/pages/[type]/[id]/settings/index.vue
+++ b/pages/[type]/[id]/settings/index.vue
@@ -143,7 +143,7 @@
       </template>
       <div class="adjacent-input">
         <label for="project-visibility">
-          <span class="label__title">Visibility</span>
+          <span class="label__title">Target Visibility</span>
           <span class="label__description">
             Listed and archived projects are visible in search. Unlisted projects are published, but
             not visible in search or on user profiles. Private projects are only accessible by

--- a/pages/[type]/[id]/settings/index.vue
+++ b/pages/[type]/[id]/settings/index.vue
@@ -143,7 +143,7 @@
       </template>
       <div class="adjacent-input">
         <label for="project-visibility">
-          <span class="label__title">Target visibility</span>
+          <span class="label__title">Visibility</span>
           <span class="label__description">
             Listed and archived projects are visible in search. Unlisted projects are published, but
             not visible in search or on user profiles. Private projects are only accessible by

--- a/pages/[type]/[id]/settings/index.vue
+++ b/pages/[type]/[id]/settings/index.vue
@@ -145,7 +145,9 @@
         <label for="project-visibility">
           <span class="label__title">Visibility</span>
           <span class="label__description">
-            Set the visibility of your project.
+            Listed and archived projects are visible in search. Unlisted projects are published, but
+            not visible in search or on user profiles. Private projects are only accessible by
+            members of the project.
             <ul class="visibility-info">
               <li>
                 <TickIcon

--- a/pages/[type]/[id]/settings/index.vue
+++ b/pages/[type]/[id]/settings/index.vue
@@ -150,23 +150,23 @@
             members of the project.
             <ul class="visibility-info">
               <li>
-                <TickIcon
+                <CheckIcon
                   v-if="visibility === 'approved' || visibility === 'archived'"
                   class="good"
                 />
-                <CheckIcon v-else class="bad" />
+                <ExitIcon v-else class="bad" />
                 Visible in search
               </li>
               <li>
-                <CheckIcon
+                <ExitIcon
                   v-if="visibility === 'unlisted' || visibility === 'private'"
                   class="bad"
                 />
-                <TickIcon v-else class="good" />
+                <CheckIcon v-else class="good" />
                 Visible on profile
               </li>
               <li>
-                <TickIcon v-if="visibility !== 'private'" class="good" />
+                <CheckIcon v-if="visibility !== 'private'" class="good" />
                 <IssuesIcon
                   v-else
                   v-tooltip="{
@@ -240,9 +240,9 @@ import FileInput from '~/components/ui/FileInput'
 import UploadIcon from '~/assets/images/utils/upload.svg'
 import SaveIcon from '~/assets/images/utils/save.svg'
 import TrashIcon from '~/assets/images/utils/trash.svg'
-import CheckIcon from '~/assets/images/utils/exit.svg'
+import ExitIcon from '~/assets/images/utils/exit.svg'
 import IssuesIcon from '~/assets/images/utils/issues.svg'
-import TickIcon from '~/assets/images/utils/check.svg'
+import CheckIcon from '~/assets/images/utils/check.svg'
 
 export default defineNuxtComponent({
   components: {
@@ -253,8 +253,8 @@ export default defineNuxtComponent({
     UploadIcon,
     SaveIcon,
     TrashIcon,
+    ExitIcon,
     CheckIcon,
-    TickIcon,
     IssuesIcon,
   },
   props: {

--- a/pages/[type]/[id]/settings/index.vue
+++ b/pages/[type]/[id]/settings/index.vue
@@ -154,11 +154,11 @@
                   v-if="visibility === 'approved' || visibility === 'archived'"
                   class="good"
                 />
-                <CrossIcon v-else class="bad" />
+                <CheckIcon v-else class="bad" />
                 Visible in search
               </li>
               <li>
-                <CrossIcon
+                <CheckIcon
                   v-if="visibility === 'unlisted' || visibility === 'private'"
                   class="bad"
                 />
@@ -240,7 +240,7 @@ import FileInput from '~/components/ui/FileInput'
 import UploadIcon from '~/assets/images/utils/upload.svg'
 import SaveIcon from '~/assets/images/utils/save.svg'
 import TrashIcon from '~/assets/images/utils/trash.svg'
-import CrossIcon from '~/assets/images/utils/exit.svg'
+import CheckIcon from '~/assets/images/utils/exit.svg'
 import IssuesIcon from '~/assets/images/utils/issues.svg'
 import TickIcon from '~/assets/images/utils/check.svg'
 
@@ -253,7 +253,7 @@ export default defineNuxtComponent({
     UploadIcon,
     SaveIcon,
     TrashIcon,
-    CrossIcon,
+    CheckIcon,
     TickIcon,
     IssuesIcon,
   },

--- a/pages/[type]/[id]/settings/index.vue
+++ b/pages/[type]/[id]/settings/index.vue
@@ -145,9 +145,39 @@
         <label for="project-visibility">
           <span class="label__title">Visibility</span>
           <span class="label__description">
-            Set the visibility of your project. Listed and archived projects are visible in search.
-            Unlisted projects are published, but not visible in search or on user profiles. Private
-            projects are only accessible by members of the project.
+            Set the visibility of your project.
+            <ul class="visibility-info">
+              <li>
+                <TickIcon
+                  v-if="visibility === 'approved' || visibility === 'archived'"
+                  class="good"
+                />
+                <CrossIcon v-else class="bad" />
+                Visible in search
+              </li>
+              <li>
+                <CrossIcon
+                  v-if="visibility === 'unlisted' || visibility === 'private'"
+                  class="bad"
+                />
+                <TickIcon v-else class="good" />
+                Visible on profile
+              </li>
+              <li>
+                <TickIcon v-if="visibility !== 'private'" class="good" />
+                <IssuesIcon
+                  v-else
+                  v-tooltip="{
+                    content:
+                      visibility === 'private'
+                        ? 'Only members will be able to view the project.'
+                        : '',
+                  }"
+                  class="warn"
+                />
+                Visible via URL
+              </li>
+            </ul>
           </span>
         </label>
         <Multiselect
@@ -208,6 +238,9 @@ import FileInput from '~/components/ui/FileInput'
 import UploadIcon from '~/assets/images/utils/upload.svg'
 import SaveIcon from '~/assets/images/utils/save.svg'
 import TrashIcon from '~/assets/images/utils/trash.svg'
+import CrossIcon from '~/assets/images/utils/exit.svg'
+import IssuesIcon from '~/assets/images/utils/issues.svg'
+import TickIcon from '~/assets/images/utils/check.svg'
 
 export default defineNuxtComponent({
   components: {
@@ -218,6 +251,9 @@ export default defineNuxtComponent({
     UploadIcon,
     SaveIcon,
     TrashIcon,
+    CrossIcon,
+    TickIcon,
+    IssuesIcon,
   },
   props: {
     project: {
@@ -390,6 +426,25 @@ export default defineNuxtComponent({
 })
 </script>
 <style lang="scss" scoped>
+.visibility-info {
+  padding: 0;
+  list-style: none;
+}
+
+svg {
+  &.good {
+    color: var(--color-brand-green);
+  }
+
+  &.bad {
+    color: var(--color-special-red);
+  }
+
+  &.warn {
+    color: var(--color-special-orange);
+  }
+}
+
 .summary-input {
   min-height: 8rem;
   max-width: 24rem;

--- a/pages/[type]/[id]/settings/index.vue
+++ b/pages/[type]/[id]/settings/index.vue
@@ -143,7 +143,7 @@
       </template>
       <div class="adjacent-input">
         <label for="project-visibility">
-          <span class="label__title">Target Visibility</span>
+          <span class="label__title">Target visibility</span>
           <span class="label__description">
             Listed and archived projects are visible in search. Unlisted projects are published, but
             not visible in search or on user profiles. Private projects are only accessible by
@@ -155,7 +155,7 @@
                   class="good"
                 />
                 <ExitIcon v-else class="bad" />
-                Visible in search
+                {{ hasModifiedVisibility() ? 'Will be v' : 'V' }}isible in search
               </li>
               <li>
                 <ExitIcon
@@ -163,7 +163,7 @@
                   class="bad"
                 />
                 <CheckIcon v-else class="good" />
-                Visible on profile
+                {{ hasModifiedVisibility() ? 'Will be v' : 'V' }}isible on profile
               </li>
               <li>
                 <CheckIcon v-if="visibility !== 'private'" class="good" />
@@ -177,7 +177,7 @@
                   }"
                   class="warn"
                 />
-                Visible via URL
+                {{ hasModifiedVisibility() ? 'Will be v' : 'V' }}isible via URL
               </li>
             </ul>
           </span>
@@ -370,6 +370,13 @@ export default defineNuxtComponent({
     },
   },
   methods: {
+    hasModifiedVisibility() {
+      const originalVisibility = this.$tag.approvedStatuses.includes(this.project.status)
+        ? this.project.status
+        : this.project.requested_status
+
+      return originalVisibility !== this.visibility
+    },
     async saveChanges() {
       if (this.hasChanges) {
         await this.patchProject(this.patchData)

--- a/pages/[type]/[id]/settings/index.vue
+++ b/pages/[type]/[id]/settings/index.vue
@@ -240,7 +240,7 @@ import FileInput from '~/components/ui/FileInput'
 import UploadIcon from '~/assets/images/utils/upload.svg'
 import SaveIcon from '~/assets/images/utils/save.svg'
 import TrashIcon from '~/assets/images/utils/trash.svg'
-import ExitIcon from '~/assets/images/utils/exit.svg'
+import ExitIcon from '~/assets/images/utils/x.svg'
 import IssuesIcon from '~/assets/images/utils/issues.svg'
 import CheckIcon from '~/assets/images/utils/check.svg'
 


### PR DESCRIPTION
## Information

Replaces the following text:

> Set the visibility of your project. Listed and archived projects are visible in search. 
Unlisted projects are published, but not visible in search or on user profiles. 
Private projects are only accessible by members of the project.

With some indicators that are much easier to understand.

Potentially could word differently? Not sure if the following should be used instead for the search and member profile bulletpoint

- Visible in search results
- Visible on member profiles

## Screenshots

![](https://i.imgur.com/S1DBP7C.png)
![](https://i.imgur.com/pNA5Z8u.png)