### PR TITLE
Always use https URL when accessing wsrv.nl

### DIFF
--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -127,7 +127,7 @@ export const md = (options = {}) => {
           return defaultImageRenderer(tokens, idx, options, env, self)
         }
       } catch (err) {}
-      token.attrs[index][1] = `//wsrv.nl/?url=${encodeURIComponent(src)}`
+      token.attrs[index][1] = `https://wsrv.nl/?url=${encodeURIComponent(src)}`
     }
 
     return defaultImageRenderer(tokens, idx, options, env, self)


### PR DESCRIPTION
This is necessary for a CSP PR on theseus that I'll open in a moment.