### PR TITLE
Fix changelog-bar overflowing

### DIFF
--- a/pages/[type]/[id]/changelog.vue
+++ b/pages/[type]/[id]/changelog.vue
@@ -147,6 +147,13 @@ function switchPage(page) {
   position: relative;
   padding-left: 1.8rem;
 
+  &:last-child {
+    .changelog-bar.duplicate {
+      height: 100%;
+      background: transparent;
+    }
+  }
+
   .changelog-bar {
     --color: var(--color-special-green);
 


### PR DESCRIPTION
Before fix:
![image](https://user-images.githubusercontent.com/43351072/233801523-3c83ec98-7030-4e03-9b3c-d9433bd22655.png)

After fix:
![image](https://user-images.githubusercontent.com/43351072/233801548-6ece4e22-43fb-44cb-9050-9ba443d27d32.png)
