### PR TITLE
add bstats.org as allowed domain name for markdown

### DIFF
--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -73,6 +73,7 @@ export const configuredXss = new xss.FilterXSS({
           'img.shields.io',
           'i.postimg.cc',
           'wsrv.nl',
+          'bstats.org',
         ]
 
         if (!allowedHostnames.includes(url.hostname)) {


### PR DESCRIPTION
## Description
As per request from discord https://discord.com/channels/734077874708938864/783153806531100673/1100549312737452102

I've added the `bstats.org` as a trusted source, to not cache graphs from there.

## Media
Before:
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/32039051/234505948-d6a21a25-b892-44a5-870f-a31ab9f4e312.png">


After:
<img width="1355" alt="image" src="https://user-images.githubusercontent.com/32039051/234505857-0c921a22-e99e-4e90-b5b0-0751918eae40.png">
