### PR TITLE
Add cf.way2muchnoise.eu as allowed image domain

### DIFF
--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -73,6 +73,7 @@ export const configuredXss = new xss.FilterXSS({
           'img.shields.io',
           'i.postimg.cc',
           'wsrv.nl',
+          'cf.way2muchnoise.eu',
         ]
 
         if (!allowedHostnames.includes(url.hostname)) {


### PR DESCRIPTION
[cf.way2muchnoise.eu](https://cf.way2muchnoise.eu/) provides badges for stats on curseforge. They are somewhat commonly used in modrinth project descriptions. Due to the current caching they easily become very outdated. In one case the badge in [extended drawers](https://modrinth.com/mod/extended-drawers) description shows about 100K less downloads when viewed on modrinth compared to other platforms ([github](https://github.com/MattiDragon/ExtendedDrawers) and [curseforge](https://www.curseforge.com/minecraft/mc-mods/extended-drawers)). 

This change disables caching for these badges to ensure they stay up to date.