### PR TITLE
Fix the remove on the Discord theme because of the way the new remove…

### DIFF
--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -35,7 +35,7 @@ export const configuredXss = new xss.FilterXSS({
         },
         {
           regex: /^https?:\/\/(www\.)?discord\.com\/widget\?id=\d{18,19}(&theme=\w+)?$/,
-          remove: [/&theme=\w+/],
+          remove: [/theme=\w+/],
         },
       ]
 


### PR DESCRIPTION
… works

Because of the way the remove works, regexes and strings to match cannot need to be prefixed with an & or a ?. 