### PR TITLE
Fix table styling

### DIFF
--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -14,14 +14,17 @@ export const configuredXss = new xss.FilterXSS({
     kbd: ['id'],
     input: ['checked', 'disabled', 'type'],
     iframe: ['width', 'height', 'allowfullscreen', 'frameborder', 'start', 'end'],
-    img: [...xss.whiteList.img, 'usemap'],
+    img: [...xss.whiteList.img, 'usemap', 'style'],
     map: ['name'],
     area: [...xss.whiteList.a, 'coords'],
     a: [...xss.whiteList.a, 'rel'],
+    td: [...xss.whiteList.td, 'style'],
+    th: [...xss.whiteList.th, 'style'],
   },
   css: {
     whiteList: {
       'image-rendering': /^pixelated$/,
+      'text-align': /^center|left|right$/,
     },
   },
   onIgnoreTagAttr: (tag, name, value) => {


### PR DESCRIPTION
# What does this change?

This changes the XSS parser to allow `td` and `th` to have the `style` attribute, and also readds support for `img` to have the `style` attribute too with the proper whitelist.

This also makes it so that `text-align` style is whitelisted for use which fixes #1175 
