### PR TITLE
fix: featured version ui shifts

### DIFF
--- a/pages/[type]/[id].vue
+++ b/pages/[type]/[id].vue
@@ -569,43 +569,46 @@
               <ChevronRightIcon class="featured-header-chevron" aria-hidden="true" />
             </nuxt-link>
           </div>
-          <NuxtLink
-            v-for="version in featuredVersions"
-            :key="version.id"
-            class="featured-version button-transparent"
-            :to="`/${project.project_type}/${
-              project.slug ? project.slug : project.id
-            }/version/${encodeURI(version.displayUrlEnding)}`"
-          >
-            <a
-              v-tooltip="
-                version.primaryFile.filename + ' (' + $formatBytes(version.primaryFile.size) + ')'
-              "
-              :href="version.primaryFile.url"
-              class="download square-button brand-button"
-              :aria-label="`Download ${version.name}`"
-              @click.stop="(event) => event.stopPropagation()"
+          <ClientOnly>
+            <NuxtLink
+              v-for="(version, index) in featuredVersions"
+              :key="index"
+              class="featured-version button-transparent"
+              :to="`/${project.project_type}/${
+                project.slug ? project.slug : project.id
+              }/version/${encodeURI(version.displayUrlEnding)}`"
+              :ref_key="`featured-version-${index}`"
             >
-              <DownloadIcon aria-hidden="true" />
-            </a>
-            <div class="info">
-              <nuxt-link
-                :to="`/${project.project_type}/${
-                  project.slug ? project.slug : project.id
-                }/version/${encodeURI(version.displayUrlEnding)}`"
-                class="top"
+              <NuxtLink
+                v-tooltip="
+                  version.primaryFile.filename + ' (' + $formatBytes(version.primaryFile.size) + ')'
+                "
+                :to="version.primaryFile.url"
+                external
+                class="download square-button brand-button"
+                :aria-label="`Download ${version.name}`"
               >
-                {{ version.name }}
-              </nuxt-link>
-              <div v-if="version.game_versions.length > 0" class="game-version item">
-                {{ version.loaders.map((x) => $formatCategory(x)).join(', ') }}
-                {{ $formatVersion(version.game_versions) }}
+                <DownloadIcon aria-hidden="true" />
+              </NuxtLink>
+              <div class="info">
+                <NuxtLink
+                  :to="`/${project.project_type}/${
+                    project.slug ? project.slug : project.id
+                  }/version/${encodeURI(version.displayUrlEnding)}`"
+                  class="top"
+                >
+                  {{ version.name }}
+                </NuxtLink>
+                <div v-if="version.game_versions.length > 0" class="game-version item">
+                  {{ version.loaders.map((x) => $formatCategory(x)).join(', ') }}
+                  {{ $formatVersion(version.game_versions) }}
+                </div>
+                <Badge v-if="version.version_type === 'release'" type="release" color="green" />
+                <Badge v-else-if="version.version_type === 'beta'" type="beta" color="orange" />
+                <Badge v-else-if="version.version_type === 'alpha'" type="alpha" color="red" />
               </div>
-              <Badge v-if="version.version_type === 'release'" type="release" color="green" />
-              <Badge v-else-if="version.version_type === 'beta'" type="beta" color="orange" />
-              <Badge v-else-if="version.version_type === 'alpha'" type="alpha" color="red" />
-            </div>
-          </NuxtLink>
+            </NuxtLink>
+          </ClientOnly>
           <hr class="card-divider" />
         </template>
         <h2 class="card-header">Project members</h2>


### PR DESCRIPTION
### Issue:
after the change i did in #1189 it broke the layout of the featured version.
![Screenshot 2023-06-12 at 12 09 57 AM](https://github.com/modrinth/knossos/assets/35883748/cffa34f0-5399-4871-893e-f0d46825816d)

the final DOM made no sense, as the content inside of the main `NuxtLink` was being generated outside of it, the fix was to only render it on the client side, as i believe it was a server render mismatch issue.

Fixed version:
![Screenshot 2023-06-12 at 12 11 54 AM](https://github.com/modrinth/knossos/assets/35883748/000bea60-3d28-46cf-a023-a09add785a81)

