### PR TITLE
fixed mobile navigation on iphones safari

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -867,7 +867,7 @@ export default defineNuxtComponent({
 
       .mobile-navbar {
         display: flex;
-        height: var(--size-mobile-navbar-height);
+        height: calc(var(--size-mobile-navbar-height) + env(safe-area-inset-bottom));
         border-radius: var(--size-rounded-card) var(--size-rounded-card) 0 0;
         padding-bottom: env(safe-area-inset-bottom);
         position: fixed;


### PR DESCRIPTION
fix: #1164 

Issue:
- when u have the toolbar url set to the top and u scroll inside the page, the bottom mobile navigation seems to change height, due to the padding thats set.
![Screenshot 2023-06-12 at 1 22 24 AM](https://github.com/modrinth/knossos/assets/35883748/79930803-7034-4479-9f01-93686a9a9eec)



fixed version:
![Screenshot 2023-06-12 at 1 19 55 AM](https://github.com/modrinth/knossos/assets/35883748/0280b218-8c80-48cf-8ec8-8ba470047603)
