### PR TITLE
Use en dash for versions range instead of em dash

### DIFF
--- a/plugins/shorthands.js
+++ b/plugins/shorthands.js
@@ -314,7 +314,7 @@ export const formatVersions = (versionArray) => {
 
   for (const interval of newIntervals) {
     if (interval.length === 2) {
-      output.push(`${interval[0][0]}—${interval[1][0]}`)
+      output.push(`${interval[0][0]}–${interval[1][0]}`)
     } else {
       output.push(interval[0][0])
     }


### PR DESCRIPTION
An en dash is the appropriate punctuation for ranges (numbers, dates, versions).

![image](https://github.com/modrinth/knossos/assets/66572326/15d83c91-8874-4f6d-b41f-779f680f1d46)


Closes #1245 