### PR TITLE
Don't run Deploy workflow on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
   deploy:
+    if: github.repository_owner == 'modrinth'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
GitHub disables workflows on forks by default, but for those folks like me who need actions to be enabled for test deploys, having Modrinth's own workflows failing is annoying. This should change it so that Deploy workflow only runs for repositories owned by Modrinth (thus this repository).