### PR TITLE
Fix spelling mistake (accross -> across)

### DIFF
--- a/pages/app.vue
+++ b/pages/app.vue
@@ -786,7 +786,7 @@ useSeoMeta({
       <div class="section-subheader">
         <div class="section-subheader-title">Download the Modrinth App</div>
         <div class="section-subheader-description">
-          Our desktop app is available accross all platforms, <br />
+          Our desktop app is available across all platforms, <br />
           choose your desired version.
         </div>
       </div>


### PR DESCRIPTION
I found a little spelling mistake in /app, here's a fix lmao