### PR TITLE
Replace project icon borders

### DIFF
--- a/components/ui/ProjectCard.vue
+++ b/components/ui/ProjectCard.vue
@@ -305,8 +305,7 @@ export default {
     img,
     svg {
       border-radius: var(--size-rounded-lg);
-      border: 4px solid var(--color-raised-bg);
-      border-bottom: none;
+      box-shadow: -2px -2px 0 2px var(--color-raised-bg), 2px -2px 0 2px var(--color-raised-bg);
     }
   }
 

--- a/pages/[type]/[id].vue
+++ b/pages/[type]/[id].vue
@@ -1159,8 +1159,7 @@ const collapsedChecklist = ref(false)
       margin-top: calc(-3rem - var(--spacing-card-lg) - 4px);
       margin-left: -4px;
       z-index: 1;
-      border: 4px solid var(--color-raised-bg);
-      border-bottom: none;
+      box-shadow: -2px -2px 0 2px var(--color-raised-bg), 2px -2px 0 2px var(--color-raised-bg);
     }
   }
   .project__header__content {


### PR DESCRIPTION
#1280

Icons in project pages with featured images and in search results with gallery view have borders that resize them from 96x96 to 88x92.

These box-shadow replacements preserve icon size while retaining visual equivalency (rounded 4px border around left, top, and right).