### PR TITLE
Support enter key for 2FA input field

### DIFF
--- a/pages/auth/sign-in.vue
+++ b/pages/auth/sign-in.vue
@@ -11,6 +11,7 @@
         maxlength="11"
         type="text"
         placeholder="Enter code..."
+        @keyup.enter="begin2FASignIn"
       />
 
       <button class="btn btn-primary continue-btn" @click="begin2FASignIn">


### PR DESCRIPTION
This PR add support to detecting enter key for 2FA input field (this improve the user experience).

I use keyup event because keypress is deprecated (https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event).