### PR TITLE
Make language label not translatable

### DIFF
--- a/locales/en-US/index.json
+++ b/locales/en-US/index.json
@@ -35,9 +35,6 @@
   "settings.language.languages.automatic": {
     "message": "Sync with the system language"
   },
-  "settings.language.languages.language-label": {
-    "message": "{translatedName}. {displayName}"
-  },
   "settings.language.languages.language-label-applying": {
     "message": "{label}. Applying..."
   },

--- a/pages/settings/language.vue
+++ b/pages/settings/language.vue
@@ -43,10 +43,6 @@ const messages = defineMessages({
     id: 'settings.language.languages.load-failed',
     defaultMessage: 'Cannot load this language. Try again in a bit.',
   },
-  languageLabel: {
-    id: 'settings.language.languages.language-label',
-    defaultMessage: '{translatedName}. {displayName}',
-  },
   languageLabelApplying: {
     id: 'settings.language.languages.language-label-applying',
     defaultMessage: '{label}. Applying...',
@@ -275,10 +271,7 @@ function onItemClick(e: MouseEvent, locale: Locale) {
 function getItemLabel(locale: Locale) {
   const label = locale.auto
     ? formatMessage(messages.automaticLocale)
-    : formatMessage(messages.languageLabel, {
-        translatedName: locale.translatedName,
-        displayName: locale.displayName,
-      })
+    : `${locale.translatedName}. ${locale.displayName}`
 
   if ($changingTo.value === locale.tag) {
     return formatMessage(messages.languageLabelApplying, { label })


### PR DESCRIPTION
This caused confusion to translators, and it doesn't seem like it would change in most of the languages. If there's going to be a need to make it use different formatting in some language, this can be easily reverted.
