### PR TITLE
Add `autocomplete` attributes to auth-related inputs 

### DIFF
--- a/pages/auth/reset-password.vue
+++ b/pages/auth/reset-password.vue
@@ -16,6 +16,7 @@
             id="email"
             v-model="email"
             type="text"
+            autocomplete="username"
             class="auth-form__input"
             placeholder="Email"
           />
@@ -35,6 +36,7 @@
             id="password"
             v-model="newPassword"
             type="password"
+            autocomplete="new-password"
             class="auth-form__input"
             placeholder="Password"
           />
@@ -47,6 +49,7 @@
             id="confirm-password"
             v-model="confirmNewPassword"
             type="password"
+            autocomplete="new-password"
             class="auth-form__input"
             placeholder="Confirm password"
           />

--- a/pages/auth/sign-in.vue
+++ b/pages/auth/sign-in.vue
@@ -57,6 +57,7 @@
             id="email"
             v-model="email"
             type="text"
+            autocomplete="username"
             class="auth-form__input"
             placeholder="Email or username"
           />
@@ -69,6 +70,7 @@
             id="password"
             v-model="password"
             type="password"
+            autocomplete="current-password"
             class="auth-form__input"
             placeholder="Password"
           />

--- a/pages/auth/sign-up.vue
+++ b/pages/auth/sign-up.vue
@@ -38,7 +38,8 @@
         <input
           id="email"
           v-model="email"
-          type="text"
+          type="email"
+          autocomplete="username"
           class="auth-form__input"
           placeholder="Email"
         />
@@ -51,6 +52,7 @@
           id="username"
           v-model="username"
           type="text"
+          autocomplete="username"
           class="auth-form__input"
           placeholder="Username"
         />
@@ -64,6 +66,7 @@
           v-model="password"
           class="auth-form__input"
           type="password"
+          autocomplete="new-password"
           placeholder="Password"
         />
       </div>
@@ -75,6 +78,7 @@
           id="confirm-password"
           v-model="confirmPassword"
           type="password"
+          autocomplete="new-password"
           class="auth-form__input"
           placeholder="Confirm password"
         />

--- a/pages/settings/account.vue
+++ b/pages/settings/account.vue
@@ -60,6 +60,7 @@
           v-model="oldPassword"
           maxlength="2048"
           type="password"
+          autocomplete="current-password"
           :placeholder="`${removePasswordMode ? 'Confirm' : 'Old'} password`"
         />
         <template v-if="!removePasswordMode">
@@ -69,6 +70,7 @@
             v-model="newPassword"
             maxlength="2048"
             type="password"
+            autocomplete="new-password"
             placeholder="New password"
           />
           <label for="confirm-new-password"
@@ -79,6 +81,7 @@
             v-model="confirmNewPassword"
             maxlength="2048"
             type="password"
+            autocomplete="new-password"
             placeholder="Confirm new password"
           />
         </template>


### PR DESCRIPTION
Currently, none of the email, username or password inputs on authentication-related pages include [`autocomplete` attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete). This means that autocompletion and password management tools provided by the browser or browser extensions have to guess the meaning of each form field.

This PR adds the appropriate attributes to the aforementioned input elements on the sign-up, sign-in, reset password, and user settings (for changing your password) pages. This lets browsers reliably provide autofill suggestions, making it easier and quicker to use those forms. It should also let some browsers suggest a randomly-generated password when a user creates a Modrinth account.

I've also changed the `type` attribute of the email input on the sign-up page from `text` to `email` so that it's semantically correct.

This was inspired by a [web.dev article on sign-in form best practices](https://web.dev/sign-in-form-best-practices).