### PR TITLE
Added padding to account for .changelog-bar offset

### DIFF
--- a/pages/[type]/[id]/changelog.vue
+++ b/pages/[type]/[id]/changelog.vue
@@ -141,8 +141,7 @@ function switchPage(page) {
 
 <style lang="scss">
 .changelog-wrapper {
-  padding: var(--spacing-card-md) var(--spacing-card-lg) calc(var(--spacing-card-md) + 0.5rem)
-    var(--spacing-card-lg);
+  padding-bottom: calc(var(--spacing-card-md) + 0.5rem);
 }
 
 .changelog-item {

--- a/pages/[type]/[id]/changelog.vue
+++ b/pages/[type]/[id]/changelog.vue
@@ -141,7 +141,8 @@ function switchPage(page) {
 
 <style lang="scss">
 .changelog-wrapper {
-  padding: var(--spacing-card-md) var(--spacing-card-lg) calc(var(--spacing-card-md) + 0.5rem) var(--spacing-card-lg);
+  padding: var(--spacing-card-md) var(--spacing-card-lg) calc(var(--spacing-card-md) + 0.5rem)
+    var(--spacing-card-lg);
 }
 
 .changelog-item {

--- a/pages/[type]/[id]/changelog.vue
+++ b/pages/[type]/[id]/changelog.vue
@@ -15,7 +15,7 @@
       :link-function="(page) => `?page=${page}`"
       @switch-page="switchPage"
     />
-    <div class="card">
+    <div class="card changelog-wrapper">
       <div
         v-for="version in filteredVersions.slice((currentPage - 1) * 20, currentPage * 20)"
         :key="version.id"
@@ -140,6 +140,10 @@ function switchPage(page) {
 </script>
 
 <style lang="scss">
+.changelog-wrapper {
+  padding: var(--spacing-card-md) var(--spacing-card-lg) calc(var(--spacing-card-md) + 0.5rem) var(--spacing-card-lg);
+}
+
 .changelog-item {
   display: block;
   margin-bottom: 1rem;


### PR DESCRIPTION
This PR is a small change to the changelog page that adds a small increase to the bottom padding.

The changelog bars have absolute positioning with a 0.5rem top offset. This leads to bars at the end of the changelog looking out of place.
Increasing the bottom padding unifies the distance from the top of the changelog card and the bottom for changelog bars:
<img width="500" alt="padding-difference" src="https://github.com/modrinth/knossos/assets/42558699/ce878b60-f49e-4d47-9004-658294a19de3">



A potential caveat is that if there is a download button at the end of the changelog it will appear slightly higher than before, which doesn't conform to the existing design patterns, though it still doesn't look bad (right and bottom offset are equal). 

Other, more involved solutions involving changing styling of the changelog bar are likely better long term, but I wanted to modify as little markup as possible.
