### PR TITLE
Try improving i18n-related SEO

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -317,8 +317,21 @@ export default defineNuxtConfig({
   modules: ['@vintl/nuxt', '@nuxtjs/turnstile'],
   vintl: {
     defaultLocale: 'en-US',
+    locales: [
+      {
+        tag: 'en-US',
+        meta: {
+          static: {
+            iso: 'en',
+          },
+        },
+      },
+    ],
     storage: 'cookie',
     parserless: 'only-prod',
+    seo: {
+      defaultLocaleHasParameter: false,
+    },
   },
   turnstile: {
     siteKey: '0x4AAAAAAAHWfmKCm7cUG869',

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/parser": "^5.59.8",
     "@vintl/compact-number": "^2.0.4",
     "@vintl/how-ago": "^2.0.1",
-    "@vintl/nuxt": "^1.3.0",
+    "@vintl/nuxt": "^1.5.0",
     "eslint": "^8.41.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-import-resolver-typescript": "^3.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ devDependencies:
     specifier: ^2.0.1
     version: 2.0.1(@formatjs/intl@2.7.2)
   '@vintl/nuxt':
-    specifier: ^1.3.0
-    version: 1.3.0(typescript@5.0.4)(vite@4.3.9)(vue@3.3.4)
+    specifier: ^1.5.0
+    version: 1.5.0(typescript@5.0.4)(vite@4.3.9)(vue@3.3.4)
   eslint:
     specifier: ^8.41.0
     version: 8.41.0
@@ -2111,21 +2111,22 @@ packages:
       intl-messageformat: 10.3.5
     dev: true
 
-  /@vintl/nuxt@1.3.0(typescript@5.0.4)(vite@4.3.9)(vue@3.3.4):
-    resolution: {integrity: sha512-gH0Db4XB3RCzOaBQtoBf/Sc9bMneyVtt7RBjrLWzzNf7gN1NJNPlrfdCVAp2si/P7dt06wRegGHaSBuQ3oQQZg==}
+  /@vintl/nuxt@1.5.0(typescript@5.0.4)(vite@4.3.9)(vue@3.3.4):
+    resolution: {integrity: sha512-HZm7ali8WGJ10teywsi+eXGOf2cvffwZYJlb40qnl1z3SnZKCYGM3ACxpb2WVmbcHqcpeGNvLWq1OnRmgfNbwg==}
     dependencies:
       '@formatjs/intl': 2.7.2(typescript@5.0.4)
       '@formatjs/intl-localematcher': 0.4.0
-      '@nuxt/kit': 3.6.1
+      '@nuxt/kit': 3.6.5
       '@vintl/unplugin': 1.2.4(vite@4.3.9)
       '@vintl/vintl': 4.2.1(typescript@5.0.4)(vue@3.3.4)
       astring: 1.8.6
-      consola: 3.2.2
+      consola: 3.2.3
       hash-sum: 2.0.0
       import-meta-resolve: 3.0.0
       pathe: 1.1.1
       picocolors: 1.0.0
       slash: 5.1.0
+      ufo: 1.1.2
       zod: 3.21.4
     transitivePeerDependencies:
       - '@vue/compiler-core'
@@ -2160,7 +2161,7 @@ packages:
       glob: 10.2.7
       import-meta-resolve: 3.0.0
       pathe: 1.1.1
-      unplugin: 1.3.2
+      unplugin: 1.4.0
       vite: 4.3.9(@types/node@20.1.0)(sass@1.58.0)
     transitivePeerDependencies:
       - '@vue/compiler-core'


### PR DESCRIPTION
- Update @vintl/nuxt to v1.5.0 (compare: [source](https://github.com/vintl-dev/nuxt/compare/%40vintl/nuxt%401.3.0...%40vintl/nuxt%401.5.0) · [package](https://renovatebot.com/diffs/npm/@vintl%2fnuxt/1.3.0/1.5.0))

- Try improving i18n-related SEO
  - Change the hreflang tag for `en-US` locale to a more generic `en` (English) from the `en-US` (English as spoken in USA).

  - Disable the host language parameter for the default locale