### PR TITLE
Disable save & remove password button when no input password.

### DIFF
--- a/pages/settings/account.vue
+++ b/pages/settings/account.vue
@@ -92,7 +92,12 @@
             Cancel
           </button>
           <template v-if="removePasswordMode">
-            <button type="button" class="iconified-button danger-button" @click="savePassword">
+            <button
+              type="button"
+              class="iconified-button danger-button"
+              :disabled="!oldPassword"
+              @click="savePassword"
+            >
               <TrashIcon />
               Remove password
             </button>
@@ -107,7 +112,16 @@
               <TrashIcon />
               Remove password
             </button>
-            <button type="button" class="iconified-button brand-button" @click="savePassword">
+            <button
+              type="button"
+              class="iconified-button brand-button"
+              :disabled="
+                newPassword.length == 0 ||
+                oldPassword.length == 0 ||
+                newPassword !== confirmNewPassword
+              "
+              @click="savePassword"
+            >
               <SaveIcon />
               Save password
             </button>


### PR DESCRIPTION
Closes #1268

Disables the save/remove button in the change/add/remove password modal for better UX.

![image](https://github.com/modrinth/knossos/assets/72168435/fab901d1-d758-4ed6-9ee0-f0720d34323e)
![image](https://github.com/modrinth/knossos/assets/72168435/7f223e4f-7a68-4b0c-83a2-3875d5bfcdbd)

