### PR TITLE
Add Negative Filters

### DIFF
--- a/components/ui/search/SearchFilter.vue
+++ b/components/ui/search/SearchFilter.vue
@@ -1,7 +1,11 @@
 <template>
-  <Checkbox
+  <TriStateCheckbox
     class="filter"
-    :model-value="activeFilters.includes(facetName)"
+    :model-value="
+      activeFilters.includes(facetName) ? 1
+        : negativeFilters.includes(facetName) ? 2
+        : 0
+    "
     :description="displayName"
     @update:model-value="toggle()"
   >
@@ -12,15 +16,15 @@
       </div>
       <span aria-hidden="true"> {{ displayName }}</span>
     </div>
-  </Checkbox>
+  </TriStateCheckbox>
 </template>
 
 <script>
-import Checkbox from '~/components/ui/Checkbox.vue'
+import TriStateCheckbox from "~/components/ui/search/TriStateCheckbox.vue";
 
 export default {
   components: {
-    Checkbox,
+    TriStateCheckbox,
   },
   props: {
     facetName: {
@@ -36,6 +40,12 @@ export default {
       default: '',
     },
     activeFilters: {
+      type: Array,
+      default() {
+        return []
+      },
+    },
+    negativeFilters: {
       type: Array,
       default() {
         return []

--- a/components/ui/search/TriStateCheckbox.vue
+++ b/components/ui/search/TriStateCheckbox.vue
@@ -1,0 +1,159 @@
+<template>
+  <div
+    class="checkbox-outer button-within"
+    :class="{ disabled }"
+    role="presentation"
+    @click="toggle"
+  >
+    <button
+      class="checkbox"
+      role="checkbox"
+      :disabled="disabled"
+      :class="{
+        checked: modelValue === 1,
+        negativeChecked: modelValue === 2,
+        collapsing: collapsingToggleStyle,
+      }"
+      :aria-label="description ?? label"
+      :aria-checked="modelValue"
+    >
+      <CheckIcon
+        v-if="modelValue === 1 && !collapsingToggleStyle"
+        aria-hidden="true"
+      />
+      <CrossIcon
+        v-if="modelValue === 2 && !collapsingToggleStyle"
+        aria-hidden="true"
+      />
+      <DropdownIcon v-else-if="collapsingToggleStyle" aria-hidden="true" />
+    </button>
+    <!-- aria-hidden is set so screenreaders only use the <button>'s aria-label -->
+    <p v-if="label" aria-hidden="true">
+      {{ label }}
+    </p>
+    <slot v-else />
+  </div>
+</template>
+
+<script>
+import CheckIcon from '~/assets/images/utils/check.svg'
+import CrossIcon from '~/assets/images/utils/x.svg'
+import DropdownIcon from '~/assets/images/utils/dropdown.svg'
+
+export default {
+  components: {
+    CheckIcon,
+    CrossIcon,
+    DropdownIcon,
+  },
+  props: {
+    label: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    description: {
+      type: String,
+      default: null,
+    },
+    modelValue: {
+      type: Number,
+      default: 0,
+    },
+    clickEvent: {
+      type: Function,
+      default: () => {},
+    },
+    collapsingToggleStyle: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['update:modelValue'],
+  methods: {
+    toggle() {
+      if (!this.disabled) {
+        this.$emit('update:modelValue', (this.modelValue + 1) % 2)
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.checkbox-outer {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+
+  p {
+    user-select: none;
+    padding: 0.2rem 0;
+    margin: 0;
+  }
+
+  &.disabled {
+    cursor: not-allowed;
+  }
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  min-width: 1rem;
+  min-height: 1rem;
+
+  padding: 0;
+  margin: 0 0.5rem 0 0;
+
+  color: var(--color-button-text);
+  background-color: var(--color-button-bg);
+  border-radius: var(--size-rounded-control);
+  box-shadow: var(--shadow-inset-sm), 0 0 0 0 transparent;
+
+  &.checked {
+    background-color: var(--color-brand);
+  }
+
+  &.negativeChecked {
+    background-color: var(--color-special-red);
+  }
+
+  svg {
+    color: var(--color-brand-inverted);
+    stroke-width: 0.2rem;
+    height: 0.8rem;
+    width: 0.8rem;
+    flex-shrink: 0;
+  }
+
+  &.collapsing {
+    background-color: transparent !important;
+    box-shadow: none;
+
+    svg {
+      color: inherit;
+      height: 1rem;
+      width: 1rem;
+      transition: transform 0.25s ease-in-out;
+    }
+
+    &.checked {
+      svg {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  &:disabled {
+    box-shadow: none;
+    cursor: not-allowed;
+  }
+}
+</style>


### PR DESCRIPTION
Supersedes #1013; closes #516.

Categories and loaders are self explanatory.

Though environments are a bit more complex:
- Except unsupported/unsupported, normal checking acts the same
  - if `Client` is checked, then mods with `client_side` set to `required` or `optional` will show
- Excludes are the inverse.
  - If `Client` is excluded, then mods with `client_side` set to `unsupported` will show. Allowing optional would make it equivalent to `Server` being checked, but also showing the pair server unsupported/client optional, which doesn't make sense here

Keeping this as a draft for now:
- Commented out code / a couple logs
- Not linted
- A large part of the toggle for Plugin loader is commented out. It didn't seem to work on the staging instance, but it should probably be decided / figured out before this is merged
- In #1013, one of the requests for change was to make the this type of checkbox it's own component instead of shoving it into the normal Checkbox. This has heavy code duplication, since the lines changed are minimal. Especially for the css section there's probably a way to not duplicate it, but I'm not knowledgeable enough in vue
- @Prospector had suggested having a button to toggle between include filters and exclude filters. (Though others disagree) The code changes to add this is minimal, it would still use the tri-state checkbox, but the logic in the toggle methods would be slightly changed