### PR TITLE
Move extra loaders and change RP Resolutions to use OR

### DIFF
--- a/composables/tag.js
+++ b/composables/tag.js
@@ -55,6 +55,7 @@ export const useTags = () =>
       ],
       dataPackLoaders: ['datapack'],
       modLoaders: ['forge', 'fabric', 'quilt', 'liteloader', 'modloader', 'rift', 'neoforge'],
+      hiddenModLoaders: ['liteloader', 'modloader', 'rift'],
     },
     projectViewModes: ['list', 'grid', 'gallery'],
     approvedStatuses: ['approved', 'archived', 'unlisted', 'private'],

--- a/pages/search/[searchProjectType].vue
+++ b/pages/search/[searchProjectType].vue
@@ -42,12 +42,23 @@
               </h3>
 
               <SearchFilter
+                v-if="header === 'resolutions'"
+                v-for="category in categories.filter((x) => x.project_type === projectType.actual)"
+                :key="category.name"
+                :active-filters="orFacets"
+                :display-name="$formatCategory(category.name)"
+                :facet-name="`categories:'${encodeURIComponent(category.name)}'`"
+                :icon="null"
+                @toggle="toggleOrFacet"
+              />
+              <SearchFilter
+                v-else
                 v-for="category in categories.filter((x) => x.project_type === projectType.actual)"
                 :key="category.name"
                 :active-filters="facets"
                 :display-name="$formatCategory(category.name)"
                 :facet-name="`categories:'${encodeURIComponent(category.name)}'`"
-                :icon="header === 'resolutions' ? null : category.icon"
+                :icon="category.icon"
                 @toggle="toggleFacet"
               />
             </div>

--- a/pages/search/[searchProjectType].vue
+++ b/pages/search/[searchProjectType].vue
@@ -41,26 +41,32 @@
                 {{ $formatCategoryHeader(header) }}
               </h3>
 
-              <SearchFilter
-                v-if="header === 'resolutions'"
-                v-for="category in categories.filter((x) => x.project_type === projectType.actual)"
-                :key="category.name"
-                :active-filters="orFacets"
-                :display-name="$formatCategory(category.name)"
-                :facet-name="`categories:'${encodeURIComponent(category.name)}'`"
-                :icon="null"
-                @toggle="toggleOrFacet"
-              />
-              <SearchFilter
-                v-else
-                v-for="category in categories.filter((x) => x.project_type === projectType.actual)"
-                :key="category.name"
-                :active-filters="facets"
-                :display-name="$formatCategory(category.name)"
-                :facet-name="`categories:'${encodeURIComponent(category.name)}'`"
-                :icon="category.icon"
-                @toggle="toggleFacet"
-              />
+              <template v-if="header === 'resolutions'">
+                <SearchFilter
+                  v-for="category in categories.filter(
+                    (x) => x.project_type === projectType.actual
+                  )"
+                  :key="category.name"
+                  :active-filters="orFacets"
+                  :display-name="$formatCategory(category.name)"
+                  :facet-name="`categories:'${encodeURIComponent(category.name)}'`"
+                  :icon="null"
+                  @toggle="toggleOrFacet"
+                />
+              </template>
+              <template v-else>
+                <SearchFilter
+                  v-for="category in categories.filter(
+                    (x) => x.project_type === projectType.actual
+                  )"
+                  :key="category.name"
+                  :active-filters="facets"
+                  :display-name="$formatCategory(category.name)"
+                  :facet-name="`categories:'${encodeURIComponent(category.name)}'`"
+                  :icon="category.icon"
+                  @toggle="toggleFacet"
+                />
+              </template>
             </div>
           </section>
           <section
@@ -79,8 +85,10 @@
             <SearchFilter
               v-for="loader in tags.loaders.filter((x) => {
                 if (projectType.id === 'mod') {
-                  return tags.loaderData.modLoaders.includes(x.name)
-                   && !tags.loaderData.hiddenModLoaders.includes(x.name)
+                  return (
+                    tags.loaderData.modLoaders.includes(x.name) &&
+                    !tags.loaderData.hiddenModLoaders.includes(x.name)
+                  )
                 } else if (projectType.id === 'plugin') {
                   return tags.loaderData.pluginLoaders.includes(x.name)
                 } else if (projectType.id === 'datapack') {
@@ -97,20 +105,23 @@
               :icon="loader.icon"
               @toggle="toggleOrFacet"
             />
-            <SearchFilter
-              v-if="projectType.id === 'mod' && showAllLoaders"
-              v-for="loader in tags.loaders.filter((x) => {
-                return tags.loaderData.modLoaders.includes(x.name)
-                && tags.loaderData.hiddenModLoaders.includes(x.name)
-              })"
-              :key="loader.name"
-              ref="loaderFilters"
-              :active-filters="orFacets"
-              :display-name="$formatCategory(loader.name)"
-              :facet-name="`categories:'${encodeURIComponent(loader.name)}'`"
-              :icon="loader.icon"
-              @toggle="toggleOrFacet"
-            />
+            <template v-if="projectType.id === 'mod' && showAllLoaders">
+              <SearchFilter
+                v-for="loader in tags.loaders.filter((x) => {
+                  return (
+                    tags.loaderData.modLoaders.includes(x.name) &&
+                    tags.loaderData.hiddenModLoaders.includes(x.name)
+                  )
+                })"
+                :key="loader.name"
+                ref="loaderFilters"
+                :active-filters="orFacets"
+                :display-name="$formatCategory(loader.name)"
+                :facet-name="`categories:'${encodeURIComponent(loader.name)}'`"
+                :icon="loader.icon"
+                @toggle="toggleOrFacet"
+              />
+            </template>
             <Checkbox
               v-if="projectType.id === 'mod'"
               v-model="showAllLoaders"

--- a/pages/search/[searchProjectType].vue
+++ b/pages/search/[searchProjectType].vue
@@ -67,16 +67,9 @@
             </h3>
             <SearchFilter
               v-for="loader in tags.loaders.filter((x) => {
-                if (
-                  projectType.id === 'mod' &&
-                  x.name !== 'forge' &&
-                  x.name !== 'fabric' &&
-                  x.name !== 'quilt' &&
-                  x.name !== 'neoforge'
-                ) {
-                  return false
-                } else if (projectType.id === 'mod' && showAllLoaders) {
+                if (projectType.id === 'mod') {
                   return tags.loaderData.modLoaders.includes(x.name)
+                   && !tags.loaderData.hiddenModLoaders.includes(x.name)
                 } else if (projectType.id === 'plugin') {
                   return tags.loaderData.pluginLoaders.includes(x.name)
                 } else if (projectType.id === 'datapack') {
@@ -96,16 +89,8 @@
             <SearchFilter
               v-if="projectType.id === 'mod' && showAllLoaders"
               v-for="loader in tags.loaders.filter((x) => {
-                if (
-                  x.name !== 'forge' &&
-                  x.name !== 'fabric' &&
-                  x.name !== 'quilt' &&
-                  x.name !== 'neoforge'
-                ) {
-                  return tags.loaderData.modLoaders.includes(x.name)
-                } else {
-                  false
-                }
+                return tags.loaderData.modLoaders.includes(x.name)
+                && tags.loaderData.hiddenModLoaders.includes(x.name)
               })"
               :key="loader.name"
               ref="loaderFilters"

--- a/pages/search/[searchProjectType].vue
+++ b/pages/search/[searchProjectType].vue
@@ -69,7 +69,6 @@
               v-for="loader in tags.loaders.filter((x) => {
                 if (
                   projectType.id === 'mod' &&
-                  !showAllLoaders &&
                   x.name !== 'forge' &&
                   x.name !== 'fabric' &&
                   x.name !== 'quilt' &&
@@ -84,6 +83,28 @@
                   return tags.loaderData.dataPackLoaders.includes(x.name)
                 } else {
                   return x.supported_project_types.includes(projectType.actual)
+                }
+              })"
+              :key="loader.name"
+              ref="loaderFilters"
+              :active-filters="orFacets"
+              :display-name="$formatCategory(loader.name)"
+              :facet-name="`categories:'${encodeURIComponent(loader.name)}'`"
+              :icon="loader.icon"
+              @toggle="toggleOrFacet"
+            />
+            <SearchFilter
+              v-if="projectType.id === 'mod' && showAllLoaders"
+              v-for="loader in tags.loaders.filter((x) => {
+                if (
+                  x.name !== 'forge' &&
+                  x.name !== 'fabric' &&
+                  x.name !== 'quilt' &&
+                  x.name !== 'neoforge'
+                ) {
+                  return tags.loaderData.modLoaders.includes(x.name)
+                } else {
+                  false
                 }
               })"
               :key="loader.name"


### PR DESCRIPTION
Right now, when the user clicks on `More` to show the rest of the loaders, the extra loaders are intermixed with the original. This is unitutive, and makes it harder to find what you're looking for and  to see what loaders are the ones behind the more.

This PR fixes that by putting all the loaders hidden by `More` at the bottom of the list

Edit:
Now also fixes #953, which changes the Resource Pack Resolution filters to be OR instead of AND