### PR TITLE
Add align to img, p, and div

### DIFF
--- a/assets/styles/components.scss
+++ b/assets/styles/components.scss
@@ -528,6 +528,7 @@
 }
 
 .markdown-body {
+  overflow-y: auto;
   h1:first-child {
     margin-top: 0;
   }

--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -14,12 +14,14 @@ export const configuredXss = new xss.FilterXSS({
     kbd: ['id'],
     input: ['checked', 'disabled', 'type'],
     iframe: ['width', 'height', 'allowfullscreen', 'frameborder', 'start', 'end'],
-    img: [...xss.whiteList.img, 'usemap', 'style'],
+    img: [...xss.whiteList.img, 'usemap', 'style', 'align'],
     map: ['name'],
     area: [...xss.whiteList.a, 'coords'],
     a: [...xss.whiteList.a, 'rel'],
     td: [...xss.whiteList.td, 'style'],
     th: [...xss.whiteList.th, 'style'],
+    p: [...xss.whiteList.p, 'align'],
+    div: [...xss.whiteList.p, 'align']
   },
   css: {
     whiteList: {


### PR DESCRIPTION
Fixes #1207 but also adds it to p and div for better Github Markdown compatibility.

Possible concerns:
- To get the img to not overflow the description/preview box, `overflow: y` was added to `.markdown-body`. I'm not 100% sure this is the best place to add it