### PR TITLE
Remove sitemap property from robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,2 @@
 User-agent: *
 Disallow:
-Sitemap: https://modrinth.com/sitemap.xml


### PR DESCRIPTION
This PR closes #1439. I chose to delete the `Sitemap` property from robots.txt instead of generating a sitemap.xml because it causes less friction. In the case that you want to generate an actual sitemap, I'll close this and recommend a module like [simple-sitemap](https://nuxt.com/modules/simple-sitemap).