### PR TITLE
Fallback to project type message on unknown types

### DIFF
--- a/utils/i18n-project-type.ts
+++ b/utils/i18n-project-type.ts
@@ -47,6 +47,14 @@ const projectTypeMessages = defineMessages({
     id: 'project-type.shader.plural',
     defaultMessage: 'Shaders',
   },
+  project: {
+    id: 'project-type.project.singular',
+    defaultMessage: 'Project',
+  },
+  projects: {
+    id: 'project-type.project.plural',
+    defaultMessage: 'Projects',
+  },
 })
 
 type ExtractSingulars<K extends string> = K extends `${infer T}s` ? T : never
@@ -54,5 +62,8 @@ type ExtractSingulars<K extends string> = K extends `${infer T}s` ? T : never
 type ProjectType = ExtractSingulars<keyof typeof projectTypeMessages>
 
 export function getProjectTypeMessage(type: ProjectType, plural = false) {
-  return projectTypeMessages[`${type}${plural ? 's' : ''}`]
+  return (
+    projectTypeMessages[`${type}${plural ? 's' : ''}`] ??
+    projectTypeMessages[`project${plural ? 's' : ''}`]
+  )
 }


### PR DESCRIPTION
This PR adds a fallback to `getProjectTypeMessage` function to return a generic project type whenever it encounters an unknown project type, ensuring there are no errors when the new project types are added.