### PR TITLE
Auto-focus 2FA input box

### DIFF
--- a/pages/auth/sign-in.vue
+++ b/pages/auth/sign-in.vue
@@ -11,6 +11,7 @@
         maxlength="11"
         type="text"
         placeholder="Enter code..."
+        autofocus
         @keyup.enter="begin2FASignIn"
       />
 


### PR DESCRIPTION
This is one of my pet peeves. I start to type in my 2FA code and realise it hasn't typed it in.

This PR simply adds the [autofocus attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus) to the input form.