### PR TITLE
Added user-images.githubusercontent.com to allowed hostnames.

### DIFF
--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -82,6 +82,7 @@ export const configuredXss = new xss.FilterXSS({
           'staging-cdn.modrinth.com',
           'github.com',
           'raw.githubusercontent.com',
+          'user-images.githubusercontent.com',
           'img.shields.io',
           'i.postimg.cc',
           'wsrv.nl',


### PR DESCRIPTION
Added the hostname user-images.githubusercontent.com which is an official GitHub hostname to the allowed hostname list to resolve the issue where gifs larger than 71000000 pixels hosted on user-images.githubusercontent.com would fail to load because wsrv.nl doesn't allow gifs to be bigger than 71000000 pixels.

Closes #1468