### PR TITLE
Fix: Add missing translation keys in index.json

### DIFF
--- a/locales/en-US/index.json
+++ b/locales/en-US/index.json
@@ -56,6 +56,12 @@
   "profile.label.edit-username": {
     "message": "Username"
   },
+  "profile.label.no-collections": {
+    "message": "This user has no collection!"
+  },
+  "profile.label.no-collections-auth": {
+    "message": "You don't have any collections.\nWould you like to <create-link>create one</create-link>?"
+  },
   "profile.label.no-projects": {
     "message": "This user has no projects!"
   },
@@ -80,6 +86,12 @@
   "project-type.all": {
     "message": "All"
   },
+  "project-type.collection.plural": {
+    "message": "Collections"
+  },
+  "project-type.collection.singular": {
+    "message": "Collection"
+  },
   "project-type.datapack.plural": {
     "message": "Data Packs"
   },
@@ -103,6 +115,12 @@
   },
   "project-type.plugin.singular": {
     "message": "Plugin"
+  },
+  "project-type.project.plural": {
+    "message": "Projects"
+  },
+  "project-type.project.singular": {
+    "message": "Project"
   },
   "project-type.resourcepack.plural": {
     "message": "Resource Packs"


### PR DESCRIPTION
With new features (like collections), I think there's been an oversight in adding these keys.

https://github.com/search?q=repo%3Amodrinth%2Fknossos%20%22profile.label.no-collections%22&type=code