### PR TITLE
Fix keypress listener on organisation member invite

### DIFF
--- a/pages/organization/[id]/settings/members.vue
+++ b/pages/organization/[id]/settings/members.vue
@@ -25,7 +25,7 @@
               organizationPermissions.MANAGE_INVITES
             )
           "
-          @keypress.enter="() => onInviteTeamMember(organization.team, currentUsername)"
+          @keypress.enter="() => onInviteTeamMember(organization.team_id, currentUsername)"
         />
         <label for="username" class="hidden">Username</label>
         <Button


### PR DESCRIPTION
When putting a username into the organisation manage members page and pressing enter an error occurs mentioning an invalid team.

The error:
![2024-01-07_10-44-06](https://github.com/modrinth/knossos/assets/5401186/8b090ba8-fca7-4af0-b869-47c827657734)

Backend request causing the error:
![2024-01-07_10-44-17](https://github.com/modrinth/knossos/assets/5401186/71315074-9ce1-4cbf-82e7-cf50659d5357)

This looks to just be a typo in the code which I have fixed by making the keypress listener run the same code as pressing the invite button.
