### PR TITLE
Fix scoped typo

### DIFF
--- a/pages/settings/sessions.vue
+++ b/pages/settings/sessions.vue
@@ -129,7 +129,7 @@ async function revokeSession(id) {
   stopLoading()
 }
 </script>
-<style lang="scss" socped>
+<style lang="scss" scoped>
 .session {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Just fix a typo on the sessions.vue file: `scoped` instead of ̀`socped`.