### PR TITLE
Disable CSS transitions when changing theme

### DIFF
--- a/composables/theme.js
+++ b/composables/theme.js
@@ -48,7 +48,13 @@ export const updateTheme = (value, updatePreference = false) => {
   }
 
   if (process.client) {
+    const css = document.createElement('style')
+    css.appendChild(document.createTextNode('*,*::after,*::before{transition:none!important}'))
+    document.head.appendChild(css)
+
     document.documentElement.className = `${theme.value.value}-mode`
+
+    setTimeout(() => document.head.removeChild(css), 1)
   }
 
   themeCookie.value = theme.value


### PR DESCRIPTION
This pull request disables CSS transitions when changing the theme, by temporarily adding a `<style>` tag to `<head>` that overrides transitions. This prevents an "unsynced" theme transition, where different elements change their colors in different ways, which looks weird for the end user.

This is best shown on [`/settings`](https://modrinth.com/settings), where the background of dropdowns and the thumb of switch toggles transition slower than the page background.