### PR TITLE
Add flatpak installation link

### DIFF
--- a/pages/app.vue
+++ b/pages/app.vue
@@ -872,6 +872,10 @@ useSeoMeta({
               <DownloadIcon />
               <span> Download the Deb </span>
             </a>
+            <a href="https://flathub.org/apps/com.modrinth.ModrinthApp" target="_blank">
+              <DownloadIcon />
+              <span> Install using Flatpak </span>
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Added Flatpak installation link for ModrinthApp. Now users can easily install ModrinthApp via Flatpak from the provided link.