### PR TITLE
Fix building for Cloudflare Nitro preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   "packageManager": "pnpm@9.3.0",
   "pnpm": {
     "patchedDependencies": {
-      "markdown-it@13.0.1": "patches/markdown-it@13.0.1.patch"
+      "markdown-it@13.0.1": "patches/markdown-it@13.0.1.patch",
+      "readable-stream@2.3.8": "patches/readable-stream@2.3.8.patch"
     }
   }
 }

--- a/patches/readable-stream@2.3.8.patch
+++ b/patches/readable-stream@2.3.8.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/_stream_readable.js b/lib/_stream_readable.js
+index 3af95cb2dbf1e9fa93d261b030b0b090df507ff7..376e6979c13264d80d96e045ddbba5258d219373 100644
+--- a/lib/_stream_readable.js
++++ b/lib/_stream_readable.js
+@@ -169,7 +169,7 @@ function ReadableState(options, stream) {
+   this.decoder = null;
+   this.encoding = null;
+   if (options.encoding) {
+-    if (!StringDecoder) StringDecoder = require('string_decoder/').StringDecoder;
++    if (!StringDecoder) StringDecoder = require('string_decoder').StringDecoder;
+     this.decoder = new StringDecoder(options.encoding);
+     this.encoding = options.encoding;
+   }
+@@ -325,7 +325,7 @@ Readable.prototype.isPaused = function () {
+ 
+ // backwards compatibility.
+ Readable.prototype.setEncoding = function (enc) {
+-  if (!StringDecoder) StringDecoder = require('string_decoder/').StringDecoder;
++  if (!StringDecoder) StringDecoder = require('string_decoder').StringDecoder;
+   this._readableState.decoder = new StringDecoder(enc);
+   this._readableState.encoding = enc;
+   return this;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   markdown-it@13.0.1:
     hash: 3vlxaukqep4gvqytxeznhg6wbq
     path: patches/markdown-it@13.0.1.patch
+  readable-stream@2.3.8:
+    hash: h52dazg37p4h3yox67pw36akse
+    path: patches/readable-stream@2.3.8.patch
 
 importers:
 
@@ -9195,7 +9198,7 @@ snapshots:
     dependencies:
       lie: 3.3.0
       pako: 1.0.11
-      readable-stream: 2.3.8
+      readable-stream: 2.3.8(patch_hash=h52dazg37p4h3yox67pw36akse)
       setimmediate: 1.0.5
 
   keyv@4.5.4:
@@ -9217,7 +9220,7 @@ snapshots:
 
   lazystream@1.0.1:
     dependencies:
-      readable-stream: 2.3.8
+      readable-stream: 2.3.8(patch_hash=h52dazg37p4h3yox67pw36akse)
 
   levn@0.4.1:
     dependencies:
@@ -10255,7 +10258,7 @@ snapshots:
       parse-json: 5.2.0
       type-fest: 0.6.0
 
-  readable-stream@2.3.8:
+  readable-stream@2.3.8(patch_hash=h52dazg37p4h3yox67pw36akse):
     dependencies:
       core-util-is: 1.0.3
       inherits: 2.0.4


### PR DESCRIPTION
It seems that Rollup node-resolve module doesn't properly deal with trailing slashes, causing it to think that `string_decoder` is a built-in Node.js dependency and attempt to import it from `unenv`, which will obviously fail, because `string_decoder` is not, in fact, a Node.js dependency, but an individual dependency of `readable-stream`.

This adds a small patch for `readable-stream@2.3.8` dependency, which removes the leading slash, which seems to fix the builds.

This probably should be reported to relevant developers (Rollup node-resolve plugin or Nitro?).