### PR TITLE
Fix Turnstile unable to read the siteKey

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -305,6 +305,8 @@ export default defineNuxtConfig({
         // @ts-ignore
         globalThis.CF_PAGES_COMMIT_SHA ||
         'unknown',
+
+      turnstile: { siteKey: '0x4AAAAAAAW3guHM6Eunbgwu' },
     },
   },
   typescript: {
@@ -361,9 +363,6 @@ export default defineNuxtConfig({
         )
       }
     },
-  },
-  turnstile: {
-    siteKey: '0x4AAAAAAAW3guHM6Eunbgwu',
   },
   nitro: {
     moduleSideEffects: ['@vintl/compact-number/locale-data'],


### PR DESCRIPTION
It seems that Nuxt Turnstile's way of setting the key in `runtimeConfig` is broken and doesn't work properly, resulting in an error in runtime, because it has to be set. This PR sets the key in `runtimeConfig` manually instead, which seems to fix the issue.