### PR TITLE
add open in app button to mod & modpack project pages

### DIFF
--- a/pages/[type]/[id].vue
+++ b/pages/[type]/[id].vue
@@ -329,7 +329,9 @@
                       hoverOnly: true,
                     },
                     { id: 'copy-id', action: () => copyId() },
-                    ...(project.project_type === 'modpack' || project.project_type === 'mod' ? [{ id: 'open-in-app', action: () => openInApp() }] : []),
+                    ...(project.project_type === 'modpack' || project.project_type === 'mod'
+                      ? [{ id: 'open-in-app', action: () => openInApp() }]
+                      : []),
                   ]"
                   :direction="cosmetics.projectLayout ? 'left' : 'right'"
                 >
@@ -358,7 +360,9 @@
                       hoverOnly: true,
                     },
                     { id: 'copy-id', action: () => copyId() },
-                    ...(project.project_type === 'modpack' || project.project_type === 'mod' ? [{ id: 'open-in-app', action: () => openInApp() }] : []),
+                    ...(project.project_type === 'modpack' || project.project_type === 'mod'
+                      ? [{ id: 'open-in-app', action: () => openInApp() }]
+                      : []),
                   ]"
                   :direction="cosmetics.projectLayout ? 'left' : 'right'"
                 >

--- a/pages/[type]/[id].vue
+++ b/pages/[type]/[id].vue
@@ -329,12 +329,14 @@
                       hoverOnly: true,
                     },
                     { id: 'copy-id', action: () => copyId() },
+                    ...(project.project_type === 'modpack' || project.project_type === 'mod' ? [{ id: 'open-in-app', action: () => openInApp() }] : []),
                   ]"
                   :direction="cosmetics.projectLayout ? 'left' : 'right'"
                 >
                   <MoreHorizontalIcon />
                   <template #report> <ReportIcon /> Report </template>
                   <template #copy-id> <ClipboardCopyIcon /> Copy ID </template>
+                  <template #open-in-app> <LinkIcon /> Open in App </template>
                 </OverflowMenu>
               </template>
               <template v-else>
@@ -356,12 +358,14 @@
                       hoverOnly: true,
                     },
                     { id: 'copy-id', action: () => copyId() },
+                    ...(project.project_type === 'modpack' || project.project_type === 'mod' ? [{ id: 'open-in-app', action: () => openInApp() }] : []),
                   ]"
                   :direction="cosmetics.projectLayout ? 'left' : 'right'"
                 >
                   <MoreHorizontalIcon />
                   <template #report> <ReportIcon /> Report </template>
                   <template #copy-id> <ClipboardCopyIcon /> Copy ID </template>
+                  <template #open-in-app> <LinkIcon /> Open in App </template>
                 </OverflowMenu>
               </template>
             </div>
@@ -1079,6 +1083,7 @@ import {
   isStaff,
   CheckIcon,
   XIcon,
+  LinkIcon,
 } from 'omorphia'
 import CrownIcon from '~/assets/images/utils/crown.svg?component'
 import CalendarIcon from '~/assets/images/utils/calendar.svg?component'
@@ -1500,6 +1505,10 @@ async function updateMembers() {
 
 async function copyId() {
   await navigator.clipboard.writeText(project.value.id)
+}
+
+function openInApp() {
+  window.location.href = `modrinth:/${window.location.pathname}`
 }
 
 const collapsedChecklist = ref(false)


### PR DESCRIPTION
I noticed that theseus takes 'modrinth://' deeplinks for mods and modpacks

I thought it would be nice to add an 'open in app' button to those pages
because as far as I know there is currently no way (other than pasting code into console)
to use unlisted mods or modpacks in the launcher
and this could be a convenient way to make that a bit better
along with just being a nice qol feature

https://github.com/modrinth/knossos/assets/97823982/dd5405a2-5bce-467b-8799-8e45ef0da3a4

_I wasn't sure about making a thread for this in discord but can if needed!_