### PR TITLE
Fix transition covering More download options btn

### DIFF
--- a/pages/app.vue
+++ b/pages/app.vue
@@ -1006,6 +1006,7 @@ useSeoMeta({
   align-items: center;
   text-align: center;
   flex-direction: column;
+  isolation: isolate;
 
   .main-subheader {
     font-size: 1.625rem;
@@ -1040,6 +1041,10 @@ useSeoMeta({
     height: auto;
     mask-image: none;
     z-index: 1;
+  }
+
+  .bottom-transition {
+    z-index: -1;
   }
 }
 


### PR DESCRIPTION
***Supersedes #1623***

This pushes bottom transition to a background level while setting it so that any z-indexes are isolated within the hero to avoid any other weirdness from happenning.
